### PR TITLE
DIGISOS-73 Scroll til overskrift på stegside

### DIFF
--- a/web/src/frontend/src/nav-soknad/components/steg/index.tsx
+++ b/web/src/frontend/src/nav-soknad/components/steg/index.tsx
@@ -24,7 +24,7 @@ const Steg: React.StatelessComponent<StegProps> = ({
 					visFeilliste={visFeilmeldinger}
 				/>
 			</div>
-			<h2 className="skjema-steg__tittel">{tittel}</h2>
+			<h2 id="stegTittel" className="skjema-steg__tittel">{tittel}</h2>
 			{children}
 		</div>
 	);

--- a/web/src/frontend/src/nav-soknad/faktum/StegFaktum.tsx
+++ b/web/src/frontend/src/nav-soknad/faktum/StegFaktum.tsx
@@ -19,6 +19,11 @@ class StegFaktum extends React.Component<
 	OwnProps & StateProps & InjectedIntlProps,
 	{}
 > {
+
+	componentDidMount() {
+		document.getElementById("stegTittel").scrollIntoView();
+	}
+
 	render() {
 		const {
 			tittelId,


### PR DESCRIPTION
Bruker scrollIntoView() som er et ganske nytt API kall som skal fungere på de fleste nettlesere: 

```
element.scrollIntoView();
```

Noen nettlesere har også støtte for animert scrolling:

```
element.scrollIntoView({behavior: "smooth"});
```

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
https://caniuse.com/#feat=scrollintoview