### PR TITLE
Scroll til toppen av siden ved bytte av steg

### DIFF
--- a/web/src/frontend/src/nav-soknad/faktum/StegFaktum.tsx
+++ b/web/src/frontend/src/nav-soknad/faktum/StegFaktum.tsx
@@ -21,9 +21,9 @@ class StegFaktum extends React.Component<
 	OwnProps & StateProps & InjectedIntlProps,
 	{}
 > {
-	tittel: HTMLElement;
+
 	componentDidMount() {
-		this.tittel.scrollIntoView();
+		document.body.scrollTop = 0;
 	}
 
 	render() {
@@ -48,7 +48,7 @@ class StegFaktum extends React.Component<
 							visFeilliste={visFeilmeldinger}
 						/>
 					</div>
-					<h2 className="skjema-steg__tittel" ref={c => (this.tittel = c)}>
+					<h2 className="skjema-steg__tittel">
 						{getIntlTextOrKey(intl, tittelId)}
 					</h2>
 					{children}


### PR DESCRIPTION
Gjort i samråd med UX desginer fra Bekk. På brukertestene scrollet flere brukere til toppen av siden først for å se kontekst før de begynte å fylle inn feltene på stegene i skjemaet.