### PR TITLE
Ikke tillatte #id-selectorer i less/css filer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # /
 /.idea
+*.idea
 *.iml
 *.ipr
 *.iws

--- a/web/src/frontend/.stylelintrc
+++ b/web/src/frontend/.stylelintrc
@@ -1,0 +1,8 @@
+{
+	"rules": {
+		"selector-max-id": 0,
+		"max-empty-lines": 2,
+		"color-no-invalid-hex": true,
+		"unit-whitelist": ["em", "rem", "%", "s", "px", "pt", "mm", "cm", "deg"]
+	}
+}

--- a/web/src/frontend/package.json
+++ b/web/src/frontend/package.json
@@ -48,6 +48,7 @@
 		"@types/react-router-dom": "^4.0.7",
 		"@types/redux-devtools-extension": "^2.13.2",
 		"body-parser": "^1.17.2",
+		"chokidar-cli": "^1.2.0",
 		"enzyme": "~2.9.1",
 		"eslint": "^4.6.1",
 		"eslint-config-prettier": "^2.4.0",
@@ -71,18 +72,21 @@
 		"prettier-eslint-cli": "^4.3.2",
 		"react-dom": "^15.6.1",
 		"react-test-renderer": "^15.6.1",
-		"replace": "0.3.0"
+		"replace": "0.3.0",
+		"stylelint": "^8.1.1"
 	},
 	"scripts": {
 		"mock-backend": "node scripts/mock_backend",
 		"build-css": "node-less-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
 		"watch-css": "npm run build-css && node-less-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
 		"start-js": "react-scripts-ts start",
-		"start": "npm-run-all -p watch-css start-js mock-backend",
+		"start": "npm-run-all -p watch-css start-js mock-backend stylelint:watch",
 		"build": "npm run build-css && react-scripts-ts build && node flytt-filer-til-webapp.js & node versjoner-prodfiler.js",
 		"test": "npm run build-css && react-scripts-ts test --env=jsdom",
 		"prettier": "prettier-eslint \"src/**/*(*.less|*.tsx|*.ts|*.css|*.json)\"",
 		"prettier:update": "prettier-eslint --write \"src/**/*(*.css|*.tsx|*.ts|*.css|*.json)\"",
+		"stylelint": "stylelint \"src/**/*.less\" --syntax less",
+		"stylelint:watch": "chokidar \"src/**/*.less\" -c \"stylelint \"src/**/*.less\" --syntax less\"",
 		"eject": "react-scripts-ts eject"
 	}
 }

--- a/web/src/frontend/package.json
+++ b/web/src/frontend/package.json
@@ -81,7 +81,7 @@
 		"watch-css": "npm run build-css && node-less-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
 		"start-js": "react-scripts-ts start",
 		"start": "npm-run-all -p watch-css start-js mock-backend stylelint:watch",
-		"build": "npm run build-css && react-scripts-ts build && stylelint:watch && node flytt-filer-til-webapp.js && node versjoner-prodfiler.js",
+		"build": "npm run stylelint && npm run build-css && react-scripts-ts build && node flytt-filer-til-webapp.js && node versjoner-prodfiler.js",
 		"test": "npm run build-css && react-scripts-ts test --env=jsdom",
 		"prettier": "prettier-eslint \"src/**/*(*.less|*.tsx|*.ts|*.css|*.json)\"",
 		"prettier:update": "prettier-eslint --write \"src/**/*(*.css|*.tsx|*.ts|*.css|*.json)\"",


### PR DESCRIPTION
Skriver en advarsel i konsollet når man kjører ```npm start``` hvis man skulle legge inn en id-selector i en less/css fil.
