### PR TITLE
Endre navn på miljøvariablene for feature toggles

### DIFF
--- a/web/src/frontend/scripts/mock_data/miljovariabler.json
+++ b/web/src/frontend/scripts/mock_data/miljovariabler.json
@@ -13,6 +13,6 @@
 	"dialogarena.cms.url": "https://appres-q1.nav.no",
 	"dittnav.link.url": "http://www.nav.no/dittnav",
 	"saksoversikt.link.url": "http://127.0.0.1:8443/saksoversikt",
-	"feature.toggle.viseTpsKontonummer.enabled": true,
-	"feature.toggle.beOmLonnslippVedlegg.enabled": true
+	"feature.frontend.sosialhjelp.kontonummer": true,
+	"feature.frontend.sosialhjelp.lonnslippvedlegg": true
 }

--- a/web/src/frontend/src/featureToggles.ts
+++ b/web/src/frontend/src/featureToggles.ts
@@ -1,6 +1,6 @@
 /* Miljøvariabler som returneres fra backend som brukes til feature toggling */
 
 export const FeatureToggles = {
-	beOmLonnslippVedlegg: "feature.toggle.beOmLonnslippVedlegg.enabled",
-	viseTpsKontonummer: "feature.toggle.viseTpsKontonummer.enabled"
+	beOmLonnslippVedlegg: "feature.frontend.sosialhjelp.lonnslippvedlegg",
+	viseTpsKontonummer: "feature.frontend.sosialhjelp.kontonummer"
 };


### PR DESCRIPTION
Gjøres for å følge navnekonvensjonen brukt på miljøvariabler i fasit på andre applikasjoner, som for eksempel:

```
soknad.fulloppsummering.enabled=true
soknad.alternativrepresentasjon.ressurs.enabled=true
feature.frontend.sosialhjelp.kontonummer=true
```