### PR TITLE
Ikke vise stillingstype

### DIFF
--- a/web/src/frontend/src/digisos/skjema/arbeidUtdanning/ArbeidsforholdDetaljer.tsx
+++ b/web/src/frontend/src/digisos/skjema/arbeidUtdanning/ArbeidsforholdDetaljer.tsx
@@ -5,14 +5,12 @@ import { FormattedMessage } from "react-intl";
 import { Faktum } from "../../../nav-soknad/types";
 
 const ArbeidsforholdDetaljer: React.StatelessComponent<{ arbeidsforhold: Faktum }> = ({ arbeidsforhold }) => {
-
 	let stillingsprosent = getFaktumPropertyVerdi(arbeidsforhold, "stillingsprosent");
 	if (stillingsprosent === "0" && getFaktumPropertyVerdi(arbeidsforhold, "stillingstype") === "variabel") {
 		stillingsprosent = "Variabel";
 	} else {
 		stillingsprosent = stillingsprosent + "%";
 	}
-	const stillingstype =  getFaktumPropertyVerdi(arbeidsforhold, "stillingstype") || "";
 
 	const tom = getFaktumPropertyVerdi(arbeidsforhold, "tom");
 
@@ -45,14 +43,6 @@ const ArbeidsforholdDetaljer: React.StatelessComponent<{ arbeidsforhold: Faktum 
 				}
 				verdi={stillingsprosent}
 			/>
-			<DetaljelisteElement
-				tittel={
-					<FormattedMessage
-						id="arbeidsforhold.stillingstype.label"/>
-				}
-				verdi={stillingstype}
-			/>
-
 		</Detaljeliste>
 	);
 };

--- a/web/src/frontend/src/nav-soknad/utils/rest-utils.ts
+++ b/web/src/frontend/src/nav-soknad/utils/rest-utils.ts
@@ -12,10 +12,10 @@ export function kjorerJetty(): boolean {
 export function getApiBaseUrl(): string {
 	if (erDev()) {
 		// Kjør mot lokal sendsoknad:
-		// return "http://localhost:8181/sendsoknad/";
+		return "http://localhost:8181/sendsoknad/";
 
 		// Kjør mot lokal mock backend:
-		return "http://localhost:3001/";
+		// return "http://localhost:3001/";
 	}
 	return kjorerJetty() ? "http://127.0.0.1:8181/sendsoknad/" : "/sendsoknad/";
 }

--- a/web/src/frontend/src/nav-soknad/utils/rest-utils.ts
+++ b/web/src/frontend/src/nav-soknad/utils/rest-utils.ts
@@ -12,10 +12,10 @@ export function kjorerJetty(): boolean {
 export function getApiBaseUrl(): string {
 	if (erDev()) {
 		// Kjør mot lokal sendsoknad:
-		return "http://localhost:8181/sendsoknad/";
+		// return "http://localhost:8181/sendsoknad/";
 
 		// Kjør mot lokal mock backend:
-		// return "http://localhost:3001/";
+		return "http://localhost:3001/";
 	}
 	return kjorerJetty() ? "http://127.0.0.1:8181/sendsoknad/" : "/sendsoknad/";
 }


### PR DESCRIPTION
Etter en diskusjon med produkteier, ble det vedtatt å ikke vise stillingstype. I stedet kan det hende noe annen informasjon fra AA registeret vises i stedet.