### PR TITLE
Revert "Fjerne radioknappene med spørsmål om man har bankkonto."

### DIFF
--- a/web/src/frontend/src/digisos/skjema/inntektFormue/Bankinnskudd.tsx
+++ b/web/src/frontend/src/digisos/skjema/inntektFormue/Bankinnskudd.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+
+import JaNeiSporsmalFaktum from "../../../nav-soknad/faktum/JaNeiSporsmalFaktum";
 import SporsmalFaktum from "../../../nav-soknad/faktum/SporsmalFaktum";
 import CheckboxFaktum, {
 	createCheckboxFaktumKey
@@ -16,55 +18,58 @@ import NivaTreSkjema from "../../../nav-soknad/components/nivaTreSkjema";
 class Bankinnskudd extends React.Component<FaktumComponentProps, {}> {
 	render() {
 		const { fakta } = this.props;
+		const innskudd = radioCheckKeys("inntekt.bankinnskudd");
 		const hvilkeInnskudd = radioCheckKeys("inntekt.bankinnskudd.true.type");
 		const hvilkeInnskuddAnnet = "inntekt.bankinnskudd.true.type.annet";
 		return (
-			<SporsmalFaktum faktumKey={hvilkeInnskudd.faktum}>
-				<CheckboxFaktum
-					id="bankinnskudd_brukskonto_checkbox"
-					faktumKey={createCheckboxFaktumKey(
-						hvilkeInnskudd.faktum,
-						"brukskonto"
-					)}
-				/>
-				<CheckboxFaktum
-					id="bankinnskudd_sparekonto_checkbox"
-					faktumKey={createCheckboxFaktumKey(
-						hvilkeInnskudd.faktum,
-						"sparekonto"
-					)}
-				/>
-				<CheckboxFaktum
-					id="bankinnskudd_bsu_checkbox"
-					faktumKey={createCheckboxFaktumKey(hvilkeInnskudd.faktum, "bsu")}
-				/>
-				<CheckboxFaktum
-					id="bankinnskudd_livsforsikring_checkbox"
-					faktumKey={createCheckboxFaktumKey(
-						hvilkeInnskudd.faktum,
-						"livsforsikring"
-					)}
-				/>
-				<CheckboxFaktum
-					id="bankinnskudd_aksjer_checkbox"
-					faktumKey={createCheckboxFaktumKey(hvilkeInnskudd.faktum, "aksjer")}
-				/>
-				<CheckboxFaktum
-					id="bankinnskudd_annet_checkbox"
-					faktumKey={createCheckboxFaktumKey(hvilkeInnskudd.faktum, "annet")}
-				/>
-				<NivaTreSkjema
-					visible={faktumIsSelected(getFaktumVerdi(fakta, hvilkeInnskuddAnnet))}
-					size="small"
-				>
-					<TextareaFaktum
-						id="bankinnskudd_annet_textarea"
-						faktumKey={`${hvilkeInnskuddAnnet}.true.beskrivelse`}
-						maxLength={400}
-						validerFunc={[getMaksLengdeFunc(400)]}
+			<JaNeiSporsmalFaktum faktumKey={innskudd.faktum}>
+				<SporsmalFaktum faktumKey={hvilkeInnskudd.faktum}>
+					<CheckboxFaktum
+						id="bankinnskudd_brukskonto_checkbox"
+						faktumKey={createCheckboxFaktumKey(
+							hvilkeInnskudd.faktum,
+							"brukskonto"
+						)}
 					/>
-				</NivaTreSkjema>
-			</SporsmalFaktum>
+					<CheckboxFaktum
+						id="bankinnskudd_sparekonto_checkbox"
+						faktumKey={createCheckboxFaktumKey(
+							hvilkeInnskudd.faktum,
+							"sparekonto"
+						)}
+					/>
+					<CheckboxFaktum
+						id="bankinnskudd_bsu_checkbox"
+						faktumKey={createCheckboxFaktumKey(hvilkeInnskudd.faktum, "bsu")}
+					/>
+					<CheckboxFaktum
+						id="bankinnskudd_livsforsikring_checkbox"
+						faktumKey={createCheckboxFaktumKey(
+							hvilkeInnskudd.faktum,
+							"livsforsikring"
+						)}
+					/>
+					<CheckboxFaktum
+						id="bankinnskudd_aksjer_checkbox"
+						faktumKey={createCheckboxFaktumKey(hvilkeInnskudd.faktum, "aksjer")}
+					/>
+					<CheckboxFaktum
+						id="bankinnskudd_annet_checkbox"
+						faktumKey={createCheckboxFaktumKey(hvilkeInnskudd.faktum, "annet")}
+					/>
+					<NivaTreSkjema
+						visible={faktumIsSelected(getFaktumVerdi(fakta, hvilkeInnskuddAnnet))}
+						size="small"
+					>
+						<TextareaFaktum
+							id="bankinnskudd_annet_textarea"
+							faktumKey={`${hvilkeInnskuddAnnet}.true.beskrivelse`}
+							maxLength={400}
+							validerFunc={[getMaksLengdeFunc(400)]}
+						/>
+					</NivaTreSkjema>
+				</SporsmalFaktum>
+			</JaNeiSporsmalFaktum>
 		);
 	}
 }


### PR DESCRIPTION
This reverts commit 88e78456a4a7741e40a917650675a9d6a05bb32d.

Fordi den commit'en gjorde slik at det ikke lenger var mulig å få registrert valgene i backend. Se branch 580 (https://github.com/navikt/soknadsosialhjelp/pull/379)