### PR TITLE
Fang opp museklikk i Edge nettlesere.

### DIFF
--- a/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
+++ b/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
@@ -270,7 +270,7 @@ class AdresseAutocomplete extends React.Component<Props, StateProps> {
 			const selectedValue = items[0][INNER_TEXT];
 			this.state.adresser.map(adresse => {
 				if(this.formaterAdresseString(adresse) === selectedValue) {
-					this.handleSelect(selectedValue, adresse)
+					this.handleSelect(selectedValue, adresse);
 					event.preventDefault();
 				}
 			});

--- a/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
+++ b/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
@@ -267,13 +267,14 @@ class AdresseAutocomplete extends React.Component<Props, StateProps> {
 		const items: HTMLCollection = document.getElementsByClassName("item-highlighted");
 		if (items && items[0]) {
 			const INNER_TEXT = "innerText";
-			const selectedValue = items[0][INNER_TEXT];
-			this.state.adresser.map(adresse => {
-				if(this.formaterAdresseString(adresse) === selectedValue) {
-					this.handleSelect(selectedValue, adresse);
-					event.preventDefault();
-				}
+			const valgtTekststreng = items[0][INNER_TEXT];
+			const valgtAdresse = this.state.adresser.find((adresse: Adresse) => {
+				return this.formaterAdresseString(adresse) === valgtTekststreng;
 			});
+			if (valgtAdresse) {
+				this.handleSelect(valgtTekststreng, valgtAdresse);
+			}
+			event.preventDefault();
 		}
 	}
 

--- a/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
+++ b/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
@@ -260,9 +260,26 @@ class AdresseAutocomplete extends React.Component<Props, StateProps> {
 		}
 	}
 
+	/*
+	 * Hack for å få museklikk på trefflisten i autocomplete til å fanges opp i Edge nettleser.
+	 */
+	handleItemClickInEdgeBrowser(event: any) {
+		const items: HTMLCollection = document.getElementsByClassName("item-highlighted");
+		if (items && items[0]) {
+			const INNER_TEXT = "innerText";
+			const selectedValue = items[0][INNER_TEXT];
+			this.state.adresser.map(adresse => {
+				if(this.formaterAdresseString(adresse) === selectedValue) {
+					this.handleSelect(selectedValue, adresse)
+					event.preventDefault();
+				}
+			});
+		}
+	}
+
 	renderMenu(children: any): React.ReactNode {
 		return (
-			<div className="menu">
+			<div className="menu" onClick={(event: any) => this.handleItemClickInEdgeBrowser(event)}>
 				{children}
 			</div>
 		);


### PR DESCRIPTION
Hack for å få museklikk på trefflisten i autocomplete til å fanges opp i Edge nettleser.

Metoden er:
 - Legg på onClick på menyen
 - Finn alle html elementer med classname item-highlighted
 - Sammenlign teksten i html elemented med adresseneobjektene vi har fått fra server
 - Kall opp koden som vanligvis kalles når man klikker på et element i trefflisten

Denne er rapportert inn som DIGISOS-824
https://jira.adeo.no/browse/DIGISOS-824
