### PR TITLE
Feature/digisos 862 sette opp grafana for måling av adressesok

### DIFF
--- a/web/src/frontend/.gitignore
+++ b/web/src/frontend/.gitignore
@@ -25,3 +25,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+chromedriver.log
+debug.log

--- a/web/src/frontend/src/digisos/skjema/personopplysninger/tps/Oppholdsadresse.tsx
+++ b/web/src/frontend/src/digisos/skjema/personopplysninger/tps/Oppholdsadresse.tsx
@@ -23,7 +23,6 @@ import { setFaktumValideringsfeil } from "../../../../nav-soknad/redux/validerin
 import VelgSoknadsmottaker from "./VelgSoknadsmottaker";
 import FinnNavKontorSpinner from "./FinnNavKontorSpinner";
 import { getIntlTextOrKey } from "../../../../nav-soknad/utils/intlUtils";
-import {loggInfo} from "../../../../nav-soknad/redux/navlogger/navloggerActions";
 
 export interface Adresse {
 	"adresse": null | string;
@@ -143,25 +142,18 @@ class Oppholdsadresse extends React.Component<Props, {}> {
 	}
 
 	brukFolkeregistrertAdresse() {
-		this.props.dispatch(loggInfo("klikk--FOLKEREGISTRERT"));
-
 		const oppholdsadressevalg = "folkeregistrert";
 		const adresseKategori = AdresseKategori.FOLKEREGISTRERT;
 		this.settAdresseOgSoknadsmottaker(null, oppholdsadressevalg, adresseKategori);
 	}
 
 	brukMidlertidigAdresse() {
-		this.props.dispatch(loggInfo("klikk--MIDLERTIDIG"));
-
 		const oppholdsadressevalg = "midlertidig";
 		const adresseKategori = AdresseKategori.MIDLERTIDIG;
 		this.settAdresseOgSoknadsmottaker(null, oppholdsadressevalg, adresseKategori);
 	}
 
 	brukSoknadAdresse() {
-
-		this.props.dispatch(loggInfo("klikk--ADRESSEAUTOCOMPLETE"));
-
 		const adresseFaktum = finnFaktum("kontakt.adresse.bruker", this.props.fakta);
 		const GATENAVN = "gatenavn";
 		const Oppholdsadressevalg = "soknad";

--- a/web/src/frontend/src/digisos/skjema/personopplysninger/tps/Oppholdsadresse.tsx
+++ b/web/src/frontend/src/digisos/skjema/personopplysninger/tps/Oppholdsadresse.tsx
@@ -23,6 +23,7 @@ import { setFaktumValideringsfeil } from "../../../../nav-soknad/redux/validerin
 import VelgSoknadsmottaker from "./VelgSoknadsmottaker";
 import FinnNavKontorSpinner from "./FinnNavKontorSpinner";
 import { getIntlTextOrKey } from "../../../../nav-soknad/utils/intlUtils";
+import {loggInfo} from "../../../../nav-soknad/redux/navlogger/navloggerActions";
 
 export interface Adresse {
 	"adresse": null | string;
@@ -142,18 +143,25 @@ class Oppholdsadresse extends React.Component<Props, {}> {
 	}
 
 	brukFolkeregistrertAdresse() {
+		this.props.dispatch(loggInfo("klikk--FOLKEREGISTRERT"));
+
 		const oppholdsadressevalg = "folkeregistrert";
 		const adresseKategori = AdresseKategori.FOLKEREGISTRERT;
 		this.settAdresseOgSoknadsmottaker(null, oppholdsadressevalg, adresseKategori);
 	}
 
 	brukMidlertidigAdresse() {
+		this.props.dispatch(loggInfo("klikk--MIDLERTIDIG"));
+
 		const oppholdsadressevalg = "midlertidig";
 		const adresseKategori = AdresseKategori.MIDLERTIDIG;
 		this.settAdresseOgSoknadsmottaker(null, oppholdsadressevalg, adresseKategori);
 	}
 
 	brukSoknadAdresse() {
+
+		this.props.dispatch(loggInfo("klikk--ADRESSEAUTOCOMPLETE"));
+
 		const adresseFaktum = finnFaktum("kontakt.adresse.bruker", this.props.fakta);
 		const GATENAVN = "gatenavn";
 		const Oppholdsadressevalg = "soknad";

--- a/web/src/frontend/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/web/src/frontend/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -15,7 +15,7 @@ import StegIndikator from "../components/stegIndikator";
 import Knapperad from "../components/knapperad";
 import { SkjemaConfig, SkjemaStegType, SkjemaSteg, Faktum } from "../types";
 import { DispatchProps, SoknadAppState } from "../redux/reduxTypes";
-import { getProgresjonFaktum } from "../utils";
+import {finnFaktum, getProgresjonFaktum} from "../utils";
 import { setVisBekreftMangler } from "../redux/oppsummering/oppsummeringActions";
 import {
 	clearFaktaValideringsfeil,
@@ -27,6 +27,7 @@ import { validerAlleFaktum } from "../validering/utils";
 import { getIntlTextOrKey, scrollToTop } from "../utils";
 import { avbrytSoknad, sendSoknad } from "../redux/soknad/soknadActions";
 import { gaVidere, gaTilbake } from "../redux/navigasjon/navigasjonActions";
+import {loggInfo} from "../redux/navlogger/navloggerActions";
 
 const stopEvent = (evt: React.FormEvent<any>) => {
 	evt.stopPropagation();
@@ -96,6 +97,13 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
 	handleGaVidere(aktivtSteg: SkjemaSteg, brukerBehandlingId: string) {
 		if (aktivtSteg.type === SkjemaStegType.oppsummering) {
 			if (this.props.oppsummeringBekreftet) {
+
+				const typeAdresseFaktum: Faktum = finnFaktum("kontakt.system.oppholdsadresse.valg", this.props.fakta);
+				const VALUE = "value";
+				if (typeAdresseFaktum && typeAdresseFaktum[VALUE]){
+					this.props.dispatch(loggInfo("klikk--" + typeAdresseFaktum[VALUE]));
+				}
+
 				this.sendSoknad(brukerBehandlingId);
 			} else {
 				this.props.dispatch(setVisBekreftMangler(true));

--- a/web/src/frontend/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/web/src/frontend/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -90,6 +90,14 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
 		}
 	}
 
+	loggAdresseTypeTilGrafana(){
+		const typeAdresseFaktum: Faktum = finnFaktum("kontakt.system.oppholdsadresse.valg", this.props.fakta);
+		const VALUE = "value";
+		if (typeAdresseFaktum && typeAdresseFaktum[VALUE]){
+			this.props.dispatch(loggInfo("klikk--" + typeAdresseFaktum[VALUE]));
+		}
+	}
+
 	sendSoknad(brukerBehandlingId: string) {
 		this.props.dispatch(sendSoknad(brukerBehandlingId));
 	}
@@ -97,13 +105,7 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
 	handleGaVidere(aktivtSteg: SkjemaSteg, brukerBehandlingId: string) {
 		if (aktivtSteg.type === SkjemaStegType.oppsummering) {
 			if (this.props.oppsummeringBekreftet) {
-
-				const typeAdresseFaktum: Faktum = finnFaktum("kontakt.system.oppholdsadresse.valg", this.props.fakta);
-				const VALUE = "value";
-				if (typeAdresseFaktum && typeAdresseFaktum[VALUE]){
-					this.props.dispatch(loggInfo("klikk--" + typeAdresseFaktum[VALUE]));
-				}
-
+				this.loggAdresseTypeTilGrafana();
 				this.sendSoknad(brukerBehandlingId);
 			} else {
 				this.props.dispatch(setVisBekreftMangler(true));


### PR DESCRIPTION
Forrandringen innebærer at det logges om brukeren har benyttet seg av folkeregistrert, midlertidig eller adressesøk adresse ved innsending av søknaden. Det logges ikke hvor mange ganger de har klikket på knappene underveis, altså kun hvilket alternativ de benyttet ved innsending.

Data blir benyttet til et pai-chart i kibana. For å finne det, gå til Kibana -> Visualize -> og søk etter DIGISOS. 