### PR TITLE
Bytter rekkefølge på hva og hvorfor på side 2 slik at hva kommer over…

### DIFF
--- a/web/src/frontend/src/@types/nav-frontend-skjema.d.ts
+++ b/web/src/frontend/src/@types/nav-frontend-skjema.d.ts
@@ -59,7 +59,7 @@ declare module "nav-frontend-skjema" {
 	}
 
 	interface TextareaProps extends React.HTMLProps<Textarea> {
-		label: React.ReactNode | any;
+		label?: React.ReactNode | any;
 		value: string;
 		maxLength?: number;
 		textareaClass?: string;

--- a/web/src/frontend/src/@types/nav-frontend-skjema.d.ts
+++ b/web/src/frontend/src/@types/nav-frontend-skjema.d.ts
@@ -59,7 +59,7 @@ declare module "nav-frontend-skjema" {
 	}
 
 	interface TextareaProps extends React.HTMLProps<Textarea> {
-		label?: React.ReactNode | any;
+		label: React.ReactNode | any;
 		value: string;
 		maxLength?: number;
 		textareaClass?: string;

--- a/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
+++ b/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
@@ -14,18 +14,7 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 		steg={DigisosSteg.begrunnelsebolk}
 		ikon={<SnakkebobleIllustrasjon/>}
 	>
-		<SporsmalFaktum faktumKey="begrunnelse.hvorfor">
-			<TextareaFaktum
-				id="begrunnelse_soknad_textarea"
-				placeholder={intl.formatMessage({
-					id: "begrunnelse.hvorfor.placeholder"
-				})}
-				faktumKey="begrunnelse.hvorfor"
-				labelId="begrunnelse.hvorfor.label"
-				maxLength={MAX_CHARS}
-				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
-			/>
-		</SporsmalFaktum>
+
 		<SporsmalFaktum faktumKey="begrunnelse.hva">
 			<TextareaFaktum
 				id="hva_sokes_det_om_textarea"
@@ -34,8 +23,18 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 				})}
 				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
 				faktumKey="begrunnelse.hva"
-				labelId="begrunnelse.hva.label"
 				maxLength={MAX_CHARS}
+			/>
+		</SporsmalFaktum>
+		<SporsmalFaktum faktumKey="begrunnelse.hvorfor">
+			<TextareaFaktum
+				id="begrunnelse_soknad_textarea"
+				placeholder={intl.formatMessage({
+					id: "begrunnelse.hvorfor.placeholder"
+				})}
+				faktumKey="begrunnelse.hvorfor"
+				maxLength={MAX_CHARS}
+				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
 			/>
 		</SporsmalFaktum>
 	</DigisosSkjemaSteg>

--- a/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
+++ b/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
@@ -24,6 +24,7 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
 				faktumKey="begrunnelse.hva"
 				maxLength={MAX_CHARS}
+				hideLabel={true}
 			/>
 		</SporsmalFaktum>
 		<SporsmalFaktum faktumKey="begrunnelse.hvorfor">
@@ -35,6 +36,7 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 				faktumKey="begrunnelse.hvorfor"
 				maxLength={MAX_CHARS}
 				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
+				hideLabel={true}
 			/>
 		</SporsmalFaktum>
 	</DigisosSkjemaSteg>

--- a/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
+++ b/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
@@ -24,7 +24,6 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
 				faktumKey="begrunnelse.hva"
 				maxLength={MAX_CHARS}
-				hideLabel={true}
 			/>
 		</SporsmalFaktum>
 		<SporsmalFaktum faktumKey="begrunnelse.hvorfor">
@@ -36,6 +35,7 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 				faktumKey="begrunnelse.hvorfor"
 				maxLength={MAX_CHARS}
 				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
+				hideLabel={true}
 			/>
 		</SporsmalFaktum>
 	</DigisosSkjemaSteg>

--- a/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
+++ b/web/src/frontend/src/digisos/skjema/begrunnelse/index.tsx
@@ -36,7 +36,6 @@ const Begrunnelse: React.StatelessComponent<InjectedIntlProps> = ({intl}) => (
 				faktumKey="begrunnelse.hvorfor"
 				maxLength={MAX_CHARS}
 				validerFunc={[getMaksLengdeFunc(MAX_CHARS)]}
-				hideLabel={true}
 			/>
 		</SporsmalFaktum>
 	</DigisosSkjemaSteg>

--- a/web/src/frontend/src/nav-soknad/faktum/TextareaFaktum.tsx
+++ b/web/src/frontend/src/nav-soknad/faktum/TextareaFaktum.tsx
@@ -72,12 +72,8 @@ class TextareaFaktum extends React.Component<Props, {}> {
 				? this.props.getPropertyVerdi()
 				: this.props.getFaktumVerdi()) || "";
 
-		let label = null;
-		if (this.props.hideLabel) {
-			label = null;
-		} else {
-			label = labelId ? getIntlTextOrKey(intl, labelId) : tekster.label
-		}
+		let label = labelId ? getIntlTextOrKey(intl, labelId) : tekster.label;
+		label = this.props.hideLabel ? "" : label;
 
 		return (
 			<Textarea

--- a/web/src/frontend/src/nav-soknad/faktum/TextareaFaktum.tsx
+++ b/web/src/frontend/src/nav-soknad/faktum/TextareaFaktum.tsx
@@ -66,6 +66,7 @@ class TextareaFaktum extends React.Component<Props, {}> {
 			intl
 		} = this.props;
 		const tekster = getInputFaktumTekst(intl, faktumKey, property);
+		console.warn(tekster);
 		const verdi =
 			(property
 				? this.props.getPropertyVerdi()
@@ -73,7 +74,7 @@ class TextareaFaktum extends React.Component<Props, {}> {
 		return (
 			<Textarea
 				id={this.props.id ? this.props.id : this.props.faktumKey + "_textarea"}
-				label={labelId ? getIntlTextOrKey(intl, labelId) : tekster.label}
+				label={labelId ? getIntlTextOrKey(intl, labelId) : null}
 				placeholder={this.props.placeholder}
 				value={verdi}
 				name={this.props.getName()}

--- a/web/src/frontend/src/nav-soknad/faktum/TextareaFaktum.tsx
+++ b/web/src/frontend/src/nav-soknad/faktum/TextareaFaktum.tsx
@@ -14,6 +14,7 @@ interface OwnProps {
 	maxLength?: number;
 	id?: string;
 	placeholder?: string;
+	hideLabel?: boolean;
 }
 
 type Props = OwnProps & InjectedFaktumComponentProps & InjectedIntlProps;
@@ -66,15 +67,22 @@ class TextareaFaktum extends React.Component<Props, {}> {
 			intl
 		} = this.props;
 		const tekster = getInputFaktumTekst(intl, faktumKey, property);
-		console.warn(tekster);
 		const verdi =
 			(property
 				? this.props.getPropertyVerdi()
 				: this.props.getFaktumVerdi()) || "";
+
+		let label = null;
+		if (this.props.hideLabel) {
+			label = null;
+		} else {
+			label = labelId ? getIntlTextOrKey(intl, labelId) : tekster.label
+		}
+
 		return (
 			<Textarea
 				id={this.props.id ? this.props.id : this.props.faktumKey + "_textarea"}
-				label={labelId ? getIntlTextOrKey(intl, labelId) : null}
+				label={label}
 				placeholder={this.props.placeholder}
 				value={verdi}
 				name={this.props.getName()}


### PR DESCRIPTION
På side 2 i søknaden er det mikset på input felt "Hva" og "Hvorfor". I tillegg skal hjelpetekst over input feltene fjernes slik at du overskriften står igjen.

Endrer slik at "Hva" kommer øverst, og "Hvorfor" underst.

I tillegg har jeg lagt til labelId som optional for input feltet, og fjernet det fra disse to input feltene på side 2