### PR TITLE
DIGISOS-908 Fortell bruker at det ikke er mulig å ettersende dokumentasjon

### DIFF
--- a/web/src/frontend/src/digisos/skjema/ettersendelse/ettersendelse.tsx
+++ b/web/src/frontend/src/digisos/skjema/ettersendelse/ettersendelse.tsx
@@ -14,6 +14,10 @@ import AvsnittMedMarger from "./avsnittMedMarger";
 import EttersendelseEkspanderbart from "./ettersendelseEkspanderbart";
 import { MargIkoner } from "./margIkoner";
 import { visToppMeny } from "../../../nav-soknad/utils/domUtils";
+import { EttersendelseFeilkode } from "../../../nav-soknad/redux/ettersendelse/ettersendelseTypes";
+import { InformasjonspanelIkon } from "../../../nav-soknad/components/informasjonspanel";
+import { DigisosFarge } from "../../../nav-soknad/components/svg/DigisosFarger";
+import Informasjonspanel from "../../../nav-soknad/components/informasjonspanel";
 
 interface OwnProps {
 	manglendeVedlegg: any[];
@@ -22,6 +26,7 @@ interface OwnProps {
 	restStatus: REST_STATUS;
 	originalSoknad: any;
 	ettersendelser: any;
+	feilKode: string;
 }
 
 type Props = OwnProps & SynligeFaktaProps & DispatchProps & InjectedIntlProps;
@@ -115,6 +120,9 @@ class Ettersendelse extends React.Component<Props, OwnState> {
 		const datoManglendeVedlegg = this.manglendeVedleggDato();
 		const ettersendelseAktivert = this.isEttersendelseAktivert();
 
+		const opprettNyEttersendelseFeilet: boolean =
+			this.props.feilKode === EttersendelseFeilkode.NY_ETTERSENDELSE_FEILET;
+
 		return (
 			<div className="ettersendelse">
 				<BannerEttersendelse>
@@ -160,21 +168,34 @@ class Ettersendelse extends React.Component<Props, OwnState> {
 						}
 					)}
 
-					<EttersendelseEkspanderbart
-						kunGenerellDokumentasjon={antallManglendeVedlegg === 0}
-						ettersendelseAktivert={ettersendelseAktivert}
-						onEttersendelse={() => this.onEttersendelseSendt()}
-					>
-						{antallManglendeVedlegg > 0 && (
-							<span>
-								<h3>{antallManglendeVedlegg} vedlegg mangler</h3>
+					{opprettNyEttersendelseFeilet && (
+						<AvsnittMedMarger>
+							<Informasjonspanel
+								synlig={true}
+								ikon={InformasjonspanelIkon.HENSYN}
+								farge={DigisosFarge.NAV_ORANSJE_LIGHTEN_40}
+							>
+								<FormattedHTMLMessage id="ettersendelse.ikke.mulig" />
+							</Informasjonspanel>
+						</AvsnittMedMarger>
+					)}
+					{!opprettNyEttersendelseFeilet && (
+						<EttersendelseEkspanderbart
+							kunGenerellDokumentasjon={antallManglendeVedlegg === 0}
+							ettersendelseAktivert={ettersendelseAktivert}
+							onEttersendelse={() => this.onEttersendelseSendt()}
+						>
+							{antallManglendeVedlegg > 0 && (
+								<span>
+								<h3>{antallManglendeVedlegg} <FormattedHTMLMessage id="ettersendelse.vedlegg.mangler" /></h3>
 								<div>{datoManglendeVedlegg}</div>
 							</span>
-						)}
-						{antallManglendeVedlegg === 0 && (
-							<h3>Last opp generell dokumentasjon</h3>
-						)}
-					</EttersendelseEkspanderbart>
+							)}
+							{antallManglendeVedlegg === 0 && (
+								<h3><FormattedHTMLMessage id="ettersendelse.generell.dokumentasjon" /></h3>
+							)}
+						</EttersendelseEkspanderbart>
+					)}
 
 					<AvsnittMedMarger venstreIkon={MargIkoner.SNAKKEBOBLER}>
 						<h3><FormattedHTMLMessage id="ettersendelse.samtale.tittel" /></h3>
@@ -199,6 +220,7 @@ export default connect((state: State, {}) => {
 		brukerbehandlingId: state.ettersendelse.brukerbehandlingId,
 		originalSoknad: state.ettersendelse.innsendte.originalSoknad,
 		ettersendelser: state.ettersendelse.innsendte.ettersendelser,
-		restStatus: state.ettersendelse.restStatus
+		restStatus: state.ettersendelse.restStatus,
+		feilKode: state.ettersendelse.feilKode
 	};
 })(injectIntl(Ettersendelse));

--- a/web/src/frontend/src/digisos/skjema/ettersendelse/ettersendelse.tsx
+++ b/web/src/frontend/src/digisos/skjema/ettersendelse/ettersendelse.tsx
@@ -171,7 +171,6 @@ class Ettersendelse extends React.Component<Props, OwnState> {
 					{opprettNyEttersendelseFeilet && (
 						<AvsnittMedMarger>
 							<Informasjonspanel
-								synlig={true}
 								ikon={InformasjonspanelIkon.HENSYN}
 								farge={DigisosFarge.NAV_ORANSJE_LIGHTEN_40}
 							>

--- a/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseActions.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseActions.ts
@@ -16,6 +16,13 @@ const opprettEttersendelse = (brukerbehandlingId: string): EttersendelseActionTy
 	};
 };
 
+const opprettEttersendelseFeilet = (brukerbehandlingId: string): EttersendelseActionTypes => {
+	return {
+		type: EttersendelseActionTypeKeys.NY_FEILET,
+		brukerbehandlingId
+	};
+};
+
 const lastOppEttersendelseVedlegg = (
 	vedleggId: number,
 	formData: FormData
@@ -86,6 +93,7 @@ const settEttersendelser = (ettersendelser: any) => {
 
 export {
 	opprettEttersendelse,
+	opprettEttersendelseFeilet,
 	lagEttersendelseOk,
 	lesEttersendelsesVedlegg,
 	lastOppEttersendelseVedlegg,

--- a/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseReducer.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseReducer.ts
@@ -1,5 +1,10 @@
 import { REST_STATUS } from "../../types/restTypes";
-import { EttersendelseActionTypeKeys, EttersendelseActionTypes, EttersendelseState } from "./ettersendelseTypes";
+import {
+	EttersendelseActionTypeKeys,
+	EttersendelseActionTypes,
+	EttersendelseFeilkode,
+	EttersendelseState
+} from "./ettersendelseTypes";
 import { Reducer } from "../reduxTypes";
 
 const initialState: EttersendelseState = {
@@ -25,6 +30,13 @@ const ettersendelseReducer: Reducer<EttersendelseState, EttersendelseActionTypes
 			return {
 				...state,
 				brukerbehandlingId: action.brukerbehandlingId
+			};
+		}
+		case EttersendelseActionTypeKeys.NY_FEILET: {
+			return {
+				...state,
+				brukerbehandlingId: action.brukerbehandlingId,
+				feilKode: EttersendelseFeilkode.NY_ETTERSENDELSE_FEILET
 			};
 		}
 		case EttersendelseActionTypeKeys.LAST_OPP: {

--- a/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseSaga.ts
@@ -8,8 +8,13 @@ import {
 	SlettEttersendtVedleggAction, SendEttersendelseAction, LesEttersendelserAction
 } from "./ettersendelseTypes";
 import {
-	lesEttersendelsesVedlegg, lastOppEttersendtVedleggOk,
-	lesEttersendteVedlegg, lagEttersendelseOk, settEttersendelser, lastOppEttersendelseFeilet
+	lesEttersendelsesVedlegg,
+	lastOppEttersendtVedleggOk,
+	lesEttersendteVedlegg,
+	lagEttersendelseOk,
+	settEttersendelser,
+	lastOppEttersendelseFeilet,
+	opprettEttersendelseFeilet
 } from "./ettersendelseActions";
 import { loggFeil } from "../navlogger/navloggerActions";
 import { navigerTilServerfeil } from "../navigasjon/navigasjonActions";
@@ -23,8 +28,8 @@ function* opprettEttersendelseSaga(action: OpprettEttersendelseAction): SagaIter
 			yield put(lesEttersendelsesVedlegg(response.brukerBehandlingId));
 		}
 	} catch (reason) {
-		yield put(loggFeil("Lag ettersendelse feilet: " + reason.toString()));
-		yield put(navigerTilServerfeil());
+		yield put(loggFeil("Opprett ettersendelse feilet: " + reason.toString()));
+		yield put(opprettEttersendelseFeilet(action.brukerbehandlingId));
 	}
 }
 

--- a/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseSaga.ts
@@ -16,7 +16,7 @@ import {
 	lastOppEttersendelseFeilet,
 	opprettEttersendelseFeilet
 } from "./ettersendelseActions";
-import { loggFeil } from "../navlogger/navloggerActions";
+import { loggFeil, loggInfo } from "../navlogger/navloggerActions";
 import { navigerTilServerfeil } from "../navigasjon/navigasjonActions";
 
 function* opprettEttersendelseSaga(action: OpprettEttersendelseAction): SagaIterator {
@@ -28,7 +28,7 @@ function* opprettEttersendelseSaga(action: OpprettEttersendelseAction): SagaIter
 			yield put(lesEttersendelsesVedlegg(response.brukerBehandlingId));
 		}
 	} catch (reason) {
-		yield put(loggFeil("Opprett ettersendelse feilet: " + reason.toString()));
+		yield put(loggInfo("Opprett ettersendelse feilet: " + reason.toString()));
 		yield put(opprettEttersendelseFeilet(action.brukerbehandlingId));
 	}
 }

--- a/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseTypes.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseTypes.ts
@@ -2,6 +2,7 @@ import { REST_STATUS } from "../../types/restTypes";
 
 export enum EttersendelseActionTypeKeys {
 	NY = "ettersendelse/NY",
+	NY_FEILET = "ettersendelse/NY_FEILET",
 	NY_OK = "ettersendelse/NY_OK",
 	LAST_OPP = "ettersendelse/LAST_OPP",
 	LAST_OPP_PENDING = "ettersendelse/LAST_OPP_PENDING",
@@ -33,6 +34,10 @@ export enum EttersendelseActionTypeKeys {
 	OTHER_ACTION = "__any_other_action_type__"
 }
 
+export enum EttersendelseFeilkode {
+	NY_ETTERSENDELSE_FEILET = "NY_ETTERSENDELSE_FEILET"
+}
+
 export interface EttersendteVedleggState {
 	data: any[];
 	restStatus: REST_STATUS;
@@ -41,6 +46,11 @@ export interface EttersendteVedleggState {
 
 export interface OpprettEttersendelseAction {
 	type: EttersendelseActionTypeKeys.NY;
+	brukerbehandlingId: string;
+}
+
+export interface OpprettEttersendelseFeiletAction {
+	type: EttersendelseActionTypeKeys.NY_FEILET;
 	brukerbehandlingId: string;
 }
 
@@ -85,6 +95,7 @@ export interface LesEttersendelserOkAction {
 }
 export type EttersendelseActionTypes =
 	OpprettEttersendelseAction
+	| OpprettEttersendelseFeiletAction
 	| LagEttersendelseOkAction
 	| LastOppEttersendelseAction
 	| LastOppEttersendelseOkAction


### PR DESCRIPTION
Når bruker går til siden for ettersendelse, enten når søknad er sendt eller fra saksoversikt, så opprettes en ettersendelse. Hvis opprett ny ettersendelse feiler (med 500 feilkode), så vis en infoboks på siden for ettersendelse med teksten "Det er ikke lenger mulig å ettersende vedlegg på denne søknaden."