### PR TITLE
DIGISOS-999 Fjerne collapsede elementer fra DOM treet

### DIFF
--- a/web/src/frontend/src/@types/react-collapse.d.ts
+++ b/web/src/frontend/src/@types/react-collapse.d.ts
@@ -12,4 +12,5 @@ declare module "react-collapse" {
 	}
 
 	export class Collapse extends React.Component<CollapseProps, {}> {}
+	export class UnmountClosed extends React.Component<CollapseProps, {}> {}
 }

--- a/web/src/frontend/src/digisos/skjema/ettersendelse/ettersendelseEkspanderbart.tsx
+++ b/web/src/frontend/src/digisos/skjema/ettersendelse/ettersendelseEkspanderbart.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Collapse } from "react-collapse";
+import { UnmountClosed } from "react-collapse";
 import { FormattedHTMLMessage } from "react-intl";
 import AvsnittMedMarger from "./avsnittMedMarger";
 import { MargIkoner } from "./margIkoner";
@@ -73,7 +73,7 @@ class EttersendelseEkspanderbart extends React.Component<Props, State> {
 					</AvsnittMedMarger>
 				) }
 
-				<Collapse
+				<UnmountClosed
 					isOpened={this.state.ekspandert }
 					onRest={() => this.onAnimasjonFerdig()}
 					className={"ettersendelse__vedlegg " +
@@ -94,7 +94,7 @@ class EttersendelseEkspanderbart extends React.Component<Props, State> {
 							/>
 						</>
 					)}
-				</Collapse>
+				</UnmountClosed>
 
 			</span>
 		);

--- a/web/src/frontend/src/nav-soknad/components/informasjonspanel/index.tsx
+++ b/web/src/frontend/src/nav-soknad/components/informasjonspanel/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Collapse } from "react-collapse";
+import { UnmountClosed } from "react-collapse";
 import Ella from "../svg/Ella";
 import Brevkonvolutt from "../svg/Brevkonvolutt";
 import {DigisosFarge} from "../svg/DigisosFarger";
@@ -93,7 +93,7 @@ class Informasjonspanel extends React.Component<OwnProps, State> {
 			return this.renderContent(false);
 		} else {
 			return (
-				<Collapse
+				<UnmountClosed
 					id="info-panel-collapse"
 					isOpened={isOpened}
 					className="react-collapse-konfigurering"
@@ -101,7 +101,7 @@ class Informasjonspanel extends React.Component<OwnProps, State> {
 					<div className={"react-collapse-wrapper"}>
 							{this.renderContent(true)}
 					</div>
-				</Collapse>
+				</UnmountClosed>
 			);
 		}
 	}

--- a/web/src/frontend/src/nav-soknad/components/nivaTreSkjema/index.tsx
+++ b/web/src/frontend/src/nav-soknad/components/nivaTreSkjema/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { loggFeil } from "../../redux/navlogger/navloggerActions";
-import { Collapse } from "react-collapse";
+import { UnmountClosed } from "react-collapse";
 
 type Sizes = "small" | "large";
 
@@ -64,9 +64,9 @@ class NivaTreSkjema extends React.Component<Props, State> {
 		}
 		if (this.state.animate === true) {
 			return (
-				<Collapse isOpened={visible} className="underskjemaWrapper">
+				<UnmountClosed isOpened={visible} className="underskjemaWrapper">
 					{content}
-				</Collapse>
+				</UnmountClosed>
 			);
 		}
 		if (!visible) {

--- a/web/src/frontend/src/nav-soknad/components/underskjema/index.tsx
+++ b/web/src/frontend/src/nav-soknad/components/underskjema/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as classNames from "classnames";
-import { Collapse } from "react-collapse";
+import { UnmountClosed } from "react-collapse";
 import { loggFeil } from "../../redux/navlogger/navloggerActions";
 
 interface UnderskjemaProps extends React.Props<any> {
@@ -45,13 +45,13 @@ const Underskjema: React.StatelessComponent<UnderskjemaProps> = ({
 	}
 	if (collapsable) {
 		return (
-			<Collapse
+			<UnmountClosed
 				isOpened={visible}
 				className="underskjema__wrapper"
 				hasNestedCollapse={true}
 			>
 				{content}
-			</Collapse>
+			</UnmountClosed>
 		);
 	}
 	return <div className="underskjema__wrapper">{renderContent()}</div>;


### PR DESCRIPTION
Problemet er at skjermleseren til David leser opp ting som er skjult for andre brukere react-collapse. Løsningen er å erstatte Collapse komponenten med UnmountClosed komponenten, som også er en del av react-collapse. 