### PR TITLE
Oppdater jetty etter sikkerhetsadvarsel fra github

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.8.v20171121</version>
+            <version>9.4.11.v20180605</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Security alert fra github:

https://github.com/navikt/soknadsosialhjelp/network/alert/web/pom.xml/org.eclipse.jetty:jetty-server/open