### PR TITLE
Fiks for adressesøk som ikke virker i IE

### DIFF
--- a/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
+++ b/web/src/frontend/src/nav-soknad/components/adresseAutocomplete/adresseAutcomplete.tsx
@@ -174,7 +174,7 @@ class AdresseAutocomplete extends React.Component<Props, StateProps> {
 				this.executePostponedSearch();
 				return;
 			}
-			fetchToJson("informasjon/adressesok?sokestreng=" + value)
+			fetchToJson("informasjon/adressesok?sokestreng=" + encodeURI(value))
 				.then((response: any) => {
 					this.setState({adresser: this.removeDuplicatesAfterTransform(response, this.formaterAdresseString).slice(0, 8)});
 					this.setState({antallAktiveSok: this.state.antallAktiveSok - 1});


### PR DESCRIPTION
URI encoding av søkestreng