### PR TITLE
Filtrere feil som klientlogger rapporterer

### DIFF
--- a/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ettersendelse/ettersendelseSaga.ts
@@ -82,8 +82,11 @@ function* lastOppEttersendelsesVedleggSaga(action: LastOppEttersendtVedleggActio
 			yield put(lesEttersendteVedlegg(response));
 		}
 	} catch (reason) {
-		yield put(lastOppEttersendelseFeilet(reason.toString(), action.vedleggId.toString()));
-		yield put(loggFeil("Last opp vedlegg for ettersendelse feilet: " + reason.toString()));
+		const errorMsg = reason.toString();
+		yield put(lastOppEttersendelseFeilet(errorMsg, action.vedleggId.toString()));
+		if ( errorMsg.match(/Unsupported Media Type|Entity Too Large/) === null ) {
+			yield put(loggFeil("Last opp vedlegg for ettersendelse feilet: " + errorMsg));
+		}
 	}
 }
 


### PR DESCRIPTION
Ikke la klientlogger rapportere ettersendelse av feil filformat eller for store filer.