### PR TITLE
Legg restStatus på søknadsdatakall på redux store

### DIFF
--- a/web/src/frontend/src/digisos/skjema/arbeidUtdanning/arbeid/Arbeid.tsx
+++ b/web/src/frontend/src/digisos/skjema/arbeidUtdanning/arbeid/Arbeid.tsx
@@ -30,7 +30,7 @@ class ArbeidView extends React.Component<Props, {}> {
 		const { soknadsdata } = this.props;
 		const arbeid = soknadsdata.arbeid;
 		arbeid.kommentarTilArbeidsforhold = verdi;
-		this.props.oppdaterSoknadsdataState(soknadsdata);
+		this.props.oppdaterSoknadsdataSti(SoknadsSti.ARBEID, arbeid);
 	}
 
 	lagreHvisGyldig() {

--- a/web/src/frontend/src/digisos/skjema/begrunnelse_ny/Begrunnelse.tsx
+++ b/web/src/frontend/src/digisos/skjema/begrunnelse_ny/Begrunnelse.tsx
@@ -32,7 +32,7 @@ class BegrunnelseSkjema extends React.Component<Props, {}> {
 	onChange(value: string, key: string) {
 		const { soknadsdata } = this.props;
 		soknadsdata.begrunnelse[key]  = value;
-		this.props.oppdaterSoknadsdataState(soknadsdata);
+		this.props.oppdaterSoknadsdataSti(SoknadsSti.BEGRUNNELSE, soknadsdata.begrunnelse);
 	}
 
 	lagreHvisGyldig() {

--- a/web/src/frontend/src/digisos/skjema/bosituasjon_ny/Bosituasjon.tsx
+++ b/web/src/frontend/src/digisos/skjema/bosituasjon_ny/Bosituasjon.tsx
@@ -47,12 +47,12 @@ class BosituasjonView extends React.Component<Props, {}> {
 		if (verdi && verdi.indexOf("annet.botype.") !== -1){
 			const botype = verdi.replace("annet.botype.","");
 			bosituasjon.botype = botype;
-			this.props.oppdaterSoknadsdataState(soknadsdata);
+			this.props.oppdaterSoknadsdataSti(SoknadsSti.BOSITUASJON, bosituasjon);
 			this.props.lagreSoknadsdata(brukerBehandlingId, SoknadsSti.BOSITUASJON, bosituasjon);
 		} else {
 			const botype = verdi;
 			bosituasjon.botype = botype;
-			this.props.oppdaterSoknadsdataState(soknadsdata);
+			this.props.oppdaterSoknadsdataSti(SoknadsSti.BOSITUASJON, bosituasjon);
 			this.props.lagreSoknadsdata(brukerBehandlingId, SoknadsSti.BOSITUASJON, bosituasjon);
 		}
 	}

--- a/web/src/frontend/src/digisos/skjema/familie/sivilstatus/SivilstatusComponent.tsx
+++ b/web/src/frontend/src/digisos/skjema/familie/sivilstatus/SivilstatusComponent.tsx
@@ -83,9 +83,8 @@ class SivilstatusComponent extends React.Component<Props, {}> {
 
 	render() {
 		const familie: Familie = this.props.soknadsdata.familie;
-		const sivilstatus = (familie && familie.sivilstatus) ? familie.sivilstatus.sivilstatus : null;
-		// const borSammenMed = this.props.sivilstatus ? this.props.sivilstatus.borSammenMed : null;
-		const borSammenMed = familie && familie.sivilstatus && familie.sivilstatus.ektefelle ? familie.sivilstatus.ektefelle.borSammenMed : null;
+		const sivilstatus = (familie && familie.sivilstatus) ? familie.sivilstatus.sivilstatus : "";
+		const borSammenMed = (familie && familie.sivilstatus && familie.sivilstatus.ektefelle) ? familie.sivilstatus.ektefelle.borSammenMed : null;
 
 		return (
 			<div style={{ border: "3px dotted red", display: "block" }}>
@@ -114,7 +113,7 @@ class SivilstatusComponent extends React.Component<Props, {}> {
 												onChange={(person: Person) => {
 													this.onChangePerson(person)
 												}}
-												oppdaterSoknadsdata={this.props.oppdaterSoknadsdataState}
+												// oppdaterSoknadsdata={this.props.oppdaterSoknadsdataState}
 											/>
 										</div>
 									</div>

--- a/web/src/frontend/src/digisos/skjema/personopplysninger/telefon/Telefon.tsx
+++ b/web/src/frontend/src/digisos/skjema/personopplysninger/telefon/Telefon.tsx
@@ -101,11 +101,6 @@ class TelefonView extends React.Component<Props, {}> {
 		const systemverdi = telefonnummer ? telefonnummer.systemverdi : "";
 		const faktumKey = telefonnummer.systemverdi === null ? FAKTUM_KEY_TELEFON : FAKTUM_KEY_SYSTEM_TELEFON;
 
-		const restStatus = soknadsdata.restStatus.personalia.telefonnummer;
-		console.warn("restSTATUS => " + restStatus);
-		if(restStatus === REST_STATUS.PENDING) {
-			return <div><h1>pending....</h1></div>
-		}
 		switch (systemverdi) {
 			case null: {
 				return (

--- a/web/src/frontend/src/digisos/skjema/personopplysninger/telefon/Telefon.tsx
+++ b/web/src/frontend/src/digisos/skjema/personopplysninger/telefon/Telefon.tsx
@@ -8,11 +8,13 @@ import SysteminfoMedSkjema from "../../../../nav-soknad/components/systeminfoMed
 import InputEnhanced from "../../../../nav-soknad/faktum/InputEnhanced";
 import { erTelefonnummer } from "../../../../nav-soknad/validering/valideringer";
 import {
-	connectSoknadsdataContainer, onEndretValideringsfeil,
+	connectSoknadsdataContainer,
+	onEndretValideringsfeil,
 	SoknadsdataContainerProps
 } from "../../../../nav-soknad/redux/soknadsdata/soknadsdataContainerUtils";
 import { SoknadsSti } from "../../../../nav-soknad/redux/soknadsdata/soknadsdataReducer";
-import {Telefonnummer} from "./telefonTypes";
+import { Telefonnummer } from "./telefonTypes";
+import { REST_STATUS } from "../../../../nav-soknad/types";
 
 const FAKTUM_KEY_TELEFON = "kontakt.telefon";
 const FAKTUM_KEY_SYSTEM_TELEFON = "kontakt.system.telefoninfo";
@@ -99,6 +101,11 @@ class TelefonView extends React.Component<Props, {}> {
 		const systemverdi = telefonnummer ? telefonnummer.systemverdi : "";
 		const faktumKey = telefonnummer.systemverdi === null ? FAKTUM_KEY_TELEFON : FAKTUM_KEY_SYSTEM_TELEFON;
 
+		const restStatus = soknadsdata.restStatus.personalia.telefonnummer;
+		console.warn("restSTATUS => " + restStatus);
+		if(restStatus === REST_STATUS.PENDING) {
+			return <div><h1>pending....</h1></div>
+		}
 		switch (systemverdi) {
 			case null: {
 				return (

--- a/web/src/frontend/src/digisos/skjema/personopplysninger/telefon/Telefon.tsx
+++ b/web/src/frontend/src/digisos/skjema/personopplysninger/telefon/Telefon.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../../../nav-soknad/redux/soknadsdata/soknadsdataContainerUtils";
 import { SoknadsSti } from "../../../../nav-soknad/redux/soknadsdata/soknadsdataReducer";
 import { Telefonnummer } from "./telefonTypes";
-import { REST_STATUS } from "../../../../nav-soknad/types";
 
 const FAKTUM_KEY_TELEFON = "kontakt.telefon";
 const FAKTUM_KEY_SYSTEM_TELEFON = "kontakt.system.telefoninfo";

--- a/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataActions.ts
+++ b/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataActions.ts
@@ -1,15 +1,23 @@
 import { Dispatch } from "../reduxTypes";
 import { fetchPut, fetchToJson } from "../../utils/rest-utils";
-import { oppdaterSoknadsdataSti, SoknadsdataType } from "./soknadsdataReducer";
+import {
+	oppdaterSoknadsdataSti,
+	settRestStatus,
+	SoknadsdataType
+} from "./soknadsdataReducer";
 import { navigerTilServerfeil } from "../navigasjon/navigasjonActions";
+import { REST_STATUS } from "../../types";
 
 const soknadsdataUrl = (brukerBehandlingId: string, sti: string): string => `soknader/${brukerBehandlingId}/${sti}`;
 
 export function hentSoknadsdata(brukerBehandlingId: string, sti: string) {
 	return (dispatch: Dispatch) => {
+		dispatch(settRestStatus(sti, REST_STATUS.PENDING));
 		fetchToJson(soknadsdataUrl(brukerBehandlingId, sti)).then((response: any) => {
 			dispatch(oppdaterSoknadsdataSti(sti, response));
+			dispatch(settRestStatus(sti, REST_STATUS.OK));
 		}).catch(() => {
+			dispatch(settRestStatus(sti, REST_STATUS.FEILET));
 			dispatch(navigerTilServerfeil());
 		});
 	}
@@ -27,8 +35,14 @@ export function lagreSoknadsdataTypet(brukerBehandlingId: string, sti: string, s
 	return lagreSoknadsdata(brukerBehandlingId, sti, soknadsdata);
 }
 
+
+
 /*
- * setPath - Opprett element i object ut fra sti hvis det ikke finnes.
+ * setPath - Oppdater sti i datastruktur.
+ *
+ *  F.eks. setPath("familie/sivilstatus/barn", {navn: 'Doffen'})
+ *
+ * Oppretter element i object ut fra sti hvis det ikke finnes.
  *
  * setPath( {}, 'familie/sivilstatus/status/barn', {navn: "Doffen"});
  *  => { familie: { sivilstatus: { status: {barn: {navn: 'Doffen' } } } }

--- a/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataActions.ts
+++ b/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataActions.ts
@@ -23,10 +23,14 @@ export function hentSoknadsdata(brukerBehandlingId: string, sti: string) {
 	}
 }
 
-export function lagreSoknadsdata(brukerBehandlingId: string, sti: string, soknadsdata: any) {
+export function lagreSoknadsdata(brukerBehandlingId: string, sti: string, soknadsdata: SoknadsdataType) {
 	return (dispatch: Dispatch) => {
+		dispatch(settRestStatus(sti, REST_STATUS.PENDING));
 		fetchPut(soknadsdataUrl(brukerBehandlingId, sti), JSON.stringify(soknadsdata)).catch(() => {
+			dispatch(settRestStatus(sti, REST_STATUS.FEILET));
 			dispatch(navigerTilServerfeil());
+		}).then((response: any) => {
+			dispatch(settRestStatus(sti, REST_STATUS.OK));
 		});
 	}
 }

--- a/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataContainerUtils.ts
+++ b/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataContainerUtils.ts
@@ -4,11 +4,9 @@ import { State } from "../../../digisos/redux/reducers";
 import { hentSoknadsdata, lagreSoknadsdata } from "./soknadsdataActions";
 import { setValideringsfeil } from "../valideringActions";
 import {
-	oppdaterSoknadsdataState,
 	oppdaterSoknadsdataSti,
 	settRestStatus,
 	Soknadsdata,
-	SoknadsdataActionVerdi,
 	SoknadsdataType
 } from "./soknadsdataReducer";
 import { REST_STATUS } from "../../types";
@@ -27,7 +25,6 @@ export interface SoknadsdataContainerProps {
 	hentSoknadsdata?: (brukerBehandlingId: string, urlPath: string) => void;
 	lagreSoknadsdata?: (brukerBehandlingId: string, urlPath: string, soknadsdata: SoknadsdataType) => void;
 	setValideringsfeil?: (feilkode: ValideringActionKey, faktumKey: string) => void;
-	oppdaterSoknadsdataState?: (soknadsdata: SoknadsdataActionVerdi) => void;
 	oppdaterSoknadsdataSti?: (sti: string, soknadsdata: SoknadsdataType) => void;
 	settRestStatus?: (sti: string, restStatus: REST_STATUS) => void;
 }
@@ -41,7 +38,6 @@ export const connectSoknadsdataContainer = connect<{}, {}, SoknadsdataContainerP
 	{
 		hentSoknadsdata,
 		lagreSoknadsdata,
-		oppdaterSoknadsdataState,
 		oppdaterSoknadsdataSti,
 		setValideringsfeil,
 		settRestStatus

--- a/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataContainerUtils.ts
+++ b/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataContainerUtils.ts
@@ -6,10 +6,12 @@ import { setValideringsfeil } from "../valideringActions";
 import {
 	oppdaterSoknadsdataState,
 	oppdaterSoknadsdataSti,
+	settRestStatus,
 	Soknadsdata,
 	SoknadsdataActionVerdi,
 	SoknadsdataType
 } from "./soknadsdataReducer";
+import { REST_STATUS } from "../../types";
 
 /*
  * Properties og redux koblinger som er felles for komponenter i søknadsskjemaet.
@@ -27,6 +29,7 @@ export interface SoknadsdataContainerProps {
 	setValideringsfeil?: (feilkode: ValideringActionKey, faktumKey: string) => void;
 	oppdaterSoknadsdataState?: (soknadsdata: SoknadsdataActionVerdi) => void;
 	oppdaterSoknadsdataSti?: (sti: string, soknadsdata: SoknadsdataType) => void;
+	settRestStatus?: (sti: string, restStatus: REST_STATUS) => void;
 }
 
 export const connectSoknadsdataContainer = connect<{}, {}, SoknadsdataContainerProps>(
@@ -40,7 +43,8 @@ export const connectSoknadsdataContainer = connect<{}, {}, SoknadsdataContainerP
 		lagreSoknadsdata,
 		oppdaterSoknadsdataState,
 		oppdaterSoknadsdataSti,
-		setValideringsfeil
+		setValideringsfeil,
+		settRestStatus
 	}
 );
 
@@ -48,7 +52,7 @@ export const connectSoknadsdataContainer = connect<{}, {}, SoknadsdataContainerP
  * Utilities
  */
 
-// For å unngå til at man dispatcher samme identiske feilmelding flere ganger, kan denne funksjonen brukes:
+// For å unngå at man dispatcher samme identiske feilmelding flere ganger, kan denne funksjonen brukes:
 export const onEndretValideringsfeil = (
 	nyFeilkode: ValideringActionKey,
 	faktumKey: string,

--- a/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataReducer.ts
+++ b/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataReducer.ts
@@ -14,10 +14,14 @@ import {
 import { initialUtdanningState, Utdanning } from "../../../digisos/skjema/arbeidUtdanning/utdanning/utdanningTypes";
 import { Arbeid, initialArbeidState } from "../../../digisos/skjema/arbeidUtdanning/arbeid/arbeidTypes";
 import { setPath } from "./soknadsdataActions";
+import { REST_STATUS } from "../../types";
 
 export enum SoknadsdataActionTypeKeys {
 	OPPDATER_SOKNADSDATA = "soknadsdata/OPPDATER",
-	OPPDATER_SOKNADSDATA_STI = "soknadsdata/OPPDATER_STI"
+	OPPDATER_SOKNADSDATA_STI = "soknadsdata/OPPDATER_STI",
+	SETT_REST_STATUS = "soknadsdata/SETT_REST_STATUS",
+	START_REST_KALL = "soknadsdata/START_REST_KALL",
+	STOPP_REST_KALL = "soknadsdata/STOPP_REST_KALL"
 }
 
 /*
@@ -51,6 +55,7 @@ export interface Soknadsdata {
 	familie: Familie;
 	utdanning: Utdanning;
 	personalia: Personalia;
+	restStatus: any;
 }
 
 export interface SoknadsdataActionVerdi {
@@ -74,8 +79,9 @@ export type SoknadsdataType =
 
 interface SoknadsdataActionType {
 	type: SoknadsdataActionTypeKeys,
-	verdi: SoknadsdataActionVerdi | SoknadsdataType,
-	sti?: string
+	verdi?: SoknadsdataActionVerdi | SoknadsdataType,
+	sti?: string,
+	restStatus?: string
 }
 
 export const initialSoknadsdataState: Soknadsdata = {
@@ -84,7 +90,13 @@ export const initialSoknadsdataState: Soknadsdata = {
 	bosituasjon: initialBosituasjonState,
 	familie: initialFamilieStatus,
 	utdanning: initialUtdanningState,
-	personalia: initialPersonaliaState
+	personalia: initialPersonaliaState,
+	restStatus: {
+		personalia: {
+			telefonnummer: REST_STATUS.INITIALISERT,
+			kontonummer: REST_STATUS.INITIALISERT
+		}
+	}
 };
 
 const SoknadsdataReducer: Reducer<Soknadsdata, SoknadsdataActionType> = (
@@ -103,8 +115,21 @@ const SoknadsdataReducer: Reducer<Soknadsdata, SoknadsdataActionType> = (
 				...setPath(state, action.sti, action.verdi)
 			};
 		}
+		case SoknadsdataActionTypeKeys.SETT_REST_STATUS: {
+			return {
+				...setPath(state, "restStatus/" + action.sti, action.restStatus)
+			}
+		}
 		default:
 			return state;
+	}
+};
+
+export const settRestStatus = (sti: string, restStatus: REST_STATUS): SoknadsdataActionType => {
+	return {
+		type: SoknadsdataActionTypeKeys.SETT_REST_STATUS,
+		sti,
+		restStatus
 	}
 };
 

--- a/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataReducer.ts
+++ b/web/src/frontend/src/nav-soknad/redux/soknadsdata/soknadsdataReducer.ts
@@ -104,12 +104,6 @@ const SoknadsdataReducer: Reducer<Soknadsdata, SoknadsdataActionType> = (
 	action
 ): any => {
 	switch (action.type) {
-		case SoknadsdataActionTypeKeys.OPPDATER_SOKNADSDATA: {
-			return {
-				...state,
-				...action.verdi
-			};
-		}
 		case SoknadsdataActionTypeKeys.OPPDATER_SOKNADSDATA_STI: {
 			return {
 				...setPath(state, action.sti, action.verdi)
@@ -130,13 +124,6 @@ export const settRestStatus = (sti: string, restStatus: REST_STATUS): Soknadsdat
 		type: SoknadsdataActionTypeKeys.SETT_REST_STATUS,
 		sti,
 		restStatus
-	}
-};
-
-export const oppdaterSoknadsdataState = (verdi: SoknadsdataActionVerdi): SoknadsdataActionType => {
-	return {
-		type: SoknadsdataActionTypeKeys.OPPDATER_SOKNADSDATA,
-		verdi
 	}
 };
 


### PR DESCRIPTION
For eksempel er rest status for kall på "personalia/telefonnummer" tilgjengelig på redux store under
`soknadsdata.restStatus.personalia.telefonnummer`.