### PR TITLE
Tving Jest til å avslutte med feilkode ved feilet test

### DIFF
--- a/web/src/frontend/package.json
+++ b/web/src/frontend/package.json
@@ -126,7 +126,7 @@
 		"start-js": "react-scripts-ts start",
 		"start": "npm-run-all -p build-css watch-css start-js mock-backend stylelint:watch",
 		"build": "npm run stylelint && npm run build-css && react-scripts-ts build && node ./scripts/flytt-filer-til-webapp.js && node versjoner-prodfiler.js",
-		"test": "npm run build-css && react-scripts-ts test --env=jsdom --setupTestFrameworkScriptFile=raf/polyfill",
+		"test": "npm run build-css && react-scripts-ts test --env=jsdom --setupTestFrameworkScriptFile=raf/polyfill --bail",
 		"tdd": "npm run build-css && react-scripts-ts test --watch --watchAll --env=jsdom --setupTestFrameworkScriptFile=raf/polyfill",
 		"prettier": "prettier-eslint \"src/**/*(*.less|*.tsx|*.ts|*.css|*.json)\"",
 		"prettier:update": "prettier-eslint --write \"src/**/*(*.css|*.tsx|*.ts|*.css|*.json)\"",


### PR DESCRIPTION
Bygget feiler ikke når stage `npm run test` feiler. Dette skyldes antageligvis at kommandoen ikke returnerer feilkode, noe som kan løses med `bail`:

```
--bail, -b                      Exit the test suite immediately upon the first
                                failing test.                         [boolsk]
```

`forceExit` kan brukes til å kjøre gjennom alle testene før Jest avslutter, men ser imidlertid ikke ut til å gi feilkode.

Kan testes med:

```
env CI=true npm run test
echo $?
```

(`env CI=true`/`env CI=1` må benyttes for å skru av watch mode.)

Dette vil feile bygget på grunn av testfeil i master.

