### PR TITLE
Redirecte brukeren til loginUrl i 401-responsen. 

### DIFF
--- a/web/src/frontend/package-lock.json
+++ b/web/src/frontend/package-lock.json
@@ -18861,7 +18861,7 @@
 		},
 		"react-dev-utils": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.2.tgz",
+			"resolved": "https://repo.adeo.no/repository/npm-public/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
 			"integrity": "sha512-Mvs6ofsc2xTjeZIrMaIfbXfsPVrbdVy/cVqq6SAacnqfMlcBpDuivhWZ1ODGeJ8HgmyWTLH971PYjj/EPCDVAw==",
 			"requires": {
 				"address": "1.0.3",
@@ -18932,7 +18932,7 @@
 		},
 		"react-is": {
 			"version": "16.7.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-0.0.0-4a1072194.tgz",
+			"resolved": "https://repo.adeo.no/repository/npm-public/react-is/-/react-is-16.7.0.tgz",
 			"integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
 			"dev": true
 		},
@@ -20028,7 +20028,7 @@
 		},
 		"react-test-renderer": {
 			"version": "16.7.0",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-0.0.0-4a1072194.tgz",
+			"resolved": "https://repo.adeo.no/repository/npm-public/react-test-renderer/-/react-test-renderer-16.7.0.tgz",
 			"integrity": "sha512-tFbhSjknSQ6+ttzmuGdv+SjQfmvGcq3PFKyPItohwhhOBmRoTf1We3Mlt3rJtIn85mjPXOkKV+TaKK4irvk9Yg==",
 			"dev": true,
 			"requires": {
@@ -20040,7 +20040,7 @@
 			"dependencies": {
 				"scheduler": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-4a1072194.tgz",
+					"resolved": "https://repo.adeo.no/repository/npm-public/scheduler/-/scheduler-0.12.0.tgz",
 					"integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
 					"dev": true,
 					"requires": {

--- a/web/src/frontend/src/digisos/index.tsx
+++ b/web/src/frontend/src/digisos/index.tsx
@@ -17,6 +17,7 @@ import AvbrytSoknad from "../nav-soknad/components/avbrytsoknad/AvbrytSoknad";
 import NavFrontendModal from "nav-frontend-modal";
 import Ettersendelse from "./skjema/ettersendelse/ettersendelse";
 import SoknadAlleredeSendtPromt from "../nav-soknad/components/soknadAlleredeSendtPromt/SoknadAlleredeSendtPromt";
+import Link from "./link";
 
 /** Setter globalt hvilket appElement react-modal skal bruke når modal dialog vises
  *
@@ -34,6 +35,7 @@ class App extends React.Component<InjectedIntlProps, {}> {
         const mock = (window.location.pathname.match(/mock$/) != null);
         const mocklogin = (window.location.pathname.match(/mock-login$/) != null);
         const undersokelse = (window.location.pathname.match(/undersokelse$/) != null);
+        const link = (window.location.pathname.match(/link$/) != null);
 
         return (
             <span>
@@ -46,6 +48,11 @@ class App extends React.Component<InjectedIntlProps, {}> {
                         path={`/informasjon`}
                         exact={true}
                         component={Informasjon}
+                    />
+					<Route
+                        path={`/link`}
+                        exact={true}
+                        component={Link}
                     />
 					<Route
                         path={`/mock`}
@@ -70,7 +77,7 @@ class App extends React.Component<InjectedIntlProps, {}> {
                     <Route path={`/serverfeil`} component={ServerFeil}/>
                     <Route component={SideIkkeFunnet}/>
 				</Switch>
-                {!ettersendelse && !informasjon && !mock && !mocklogin && !undersokelse && (
+                {!ettersendelse && !informasjon && !link && !mock && !mocklogin && !undersokelse && (
                     <span>
 					<Prompt
                         message={loc =>
@@ -87,7 +94,7 @@ class App extends React.Component<InjectedIntlProps, {}> {
                         {this.props.children}
 				</span>
                 )}
-                {!skjema && !informasjon && !mock && !mocklogin && !undersokelse && (
+                {!skjema && !informasjon && !link && !mock && !mocklogin && !undersokelse && (
                     <span>
                     <Prompt
                         message={loc =>

--- a/web/src/frontend/src/digisos/link/index.tsx
+++ b/web/src/frontend/src/digisos/link/index.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {connect} from "react-redux";
+import {DispatchProps, SoknadAppState} from "../../nav-soknad/redux/reduxTypes";
+import {Redirect} from "react-router";
+import {LedetekstState} from "../../nav-soknad/redux/ledetekster/ledeteksterTypes";
+import {REST_STATUS} from "../../nav-soknad/types";
+import {setLinkVisited} from "../../nav-soknad/redux/authentication/authenticationActions";
+
+interface IntlProviderProps {
+	children: React.ReactNode;
+}
+
+interface StateProps {
+	ledetekster: LedetekstState;
+	initRestStatus: REST_STATUS;
+	linkVisited: boolean;
+}
+
+type Props = StateProps & DispatchProps & IntlProviderProps;
+
+class Link extends React.Component<Props, {}> {
+
+
+	render(){
+
+		this.props.dispatch(setLinkVisited());
+
+		const url = new URL(window.location.href);
+		let urlPath = url.searchParams.get("goto");
+		const contextPath = "soknadsosialhjelp";
+		const regexp = new RegExp("/" + contextPath);
+		urlPath = urlPath.replace(regexp,"");
+
+		return(
+			<div className="application-spinner">
+				<Redirect to={urlPath}/>
+			</div>
+		)
+	}
+}
+
+export default connect((state: SoknadAppState) => {
+	return {
+		linkVisited: state.authentication.linkVisited,
+	};
+})(Link);

--- a/web/src/frontend/src/digisos/redux/reducers.ts
+++ b/web/src/frontend/src/digisos/redux/reducers.ts
@@ -20,6 +20,7 @@ import MockReducer from "../mock/mockReducer";
 import SoknadsdataReducer from "../../nav-soknad/redux/soknadsdata/soknadsdataReducer";
 import OpplysningerReducer from "../../nav-soknad/redux/okonomiskeOpplysninger/opplysningerReducer";
 import FilReducer from "../../nav-soknad/redux/fil/filReducer";
+import AuthenticationReducer from "../../nav-soknad/redux/authentication/authenticationReducer";
 
 export interface State extends SoknadAppState {
 	synligefakta: SynligeFaktaState;
@@ -44,7 +45,8 @@ const reducers = combineReducers({
 	mockData: MockReducer,
 	soknadsdata: SoknadsdataReducer,
 	okonomiskeOpplysninger: OpplysningerReducer,
-	filopplasting: FilReducer
+	filopplasting: FilReducer,
+	authentication: AuthenticationReducer
 });
 
 export default reducers;

--- a/web/src/frontend/src/nav-soknad/redux/authentication/authenticationActions.ts
+++ b/web/src/frontend/src/nav-soknad/redux/authentication/authenticationActions.ts
@@ -1,0 +1,13 @@
+import {AuthenticationActionTypeKeys, AuthenticationActionTypes} from "./authenticationTypes";
+
+export const authenticateUser = (): AuthenticationActionTypes => {
+	return {
+		type: AuthenticationActionTypeKeys.AUTHENTICATE_USER
+	};
+};
+
+export const setLinkVisited = (): AuthenticationActionTypes => {
+	return {
+		type: AuthenticationActionTypeKeys.LINK_VISITED
+	};
+}

--- a/web/src/frontend/src/nav-soknad/redux/authentication/authenticationReducer.ts
+++ b/web/src/frontend/src/nav-soknad/redux/authentication/authenticationReducer.ts
@@ -1,0 +1,19 @@
+import {AuthenticationActionTypeKeys, AuthenticationActionTypes, AuthenticationState} from "./authenticationTypes";
+
+const initialState: AuthenticationState = {
+	linkVisited: false,
+};
+
+export default (
+	state: AuthenticationState = initialState,
+	action: AuthenticationActionTypes
+) => {
+	switch (action.type) {
+		case AuthenticationActionTypeKeys.LINK_VISITED:
+			const AUTH_LINK_VISITED = "sosialhjelpSoknadAuthLinkVisited";
+			window[AUTH_LINK_VISITED] = true;
+		default:
+			return state;
+	}
+};
+

--- a/web/src/frontend/src/nav-soknad/redux/authentication/authenticationSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/authentication/authenticationSaga.ts
@@ -1,0 +1,19 @@
+import {takeEvery} from "redux-saga/effects";
+import {AuthenticationActionTypeKeys} from "./authenticationTypes";
+import {hentTilgangSaga} from "../tilgang/tilgangSaga";
+import {SagaIterator} from "redux-saga";
+import {hentTeksterSaga} from "../ledetekster/ledeteksterSaga";
+import {hentMiljovariablerSaga} from "../miljovariabler/miljoVariablerSaga";
+
+
+function* authenticateUserSaga(): SagaIterator {
+	yield* hentTilgangSaga();
+	yield* hentTeksterSaga();
+	yield* hentMiljovariablerSaga();
+}
+
+function* authenticationSaga(): any {
+	yield takeEvery(AuthenticationActionTypeKeys.AUTHENTICATE_USER, authenticateUserSaga)
+}
+
+export default authenticationSaga;

--- a/web/src/frontend/src/nav-soknad/redux/authentication/authenticationTypes.ts
+++ b/web/src/frontend/src/nav-soknad/redux/authentication/authenticationTypes.ts
@@ -1,0 +1,21 @@
+export type AuthenticationActionTypes =
+	| AuthenticateUser
+	| LinkVisited
+
+
+export interface AuthenticateUser {
+	type: AuthenticationActionTypeKeys.AUTHENTICATE_USER;
+}
+
+export interface LinkVisited {
+	type: AuthenticationActionTypeKeys.LINK_VISITED
+}
+
+export enum AuthenticationActionTypeKeys {
+	AUTHENTICATE_USER = "authentication/AUTHENTICATE_USER",
+	LINK_VISITED = "authentication/LINK_VISITED"
+}
+
+export interface AuthenticationState {
+	linkVisited: boolean;
+}

--- a/web/src/frontend/src/nav-soknad/redux/ledetekster/ledeteksterSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/ledetekster/ledeteksterSaga.ts
@@ -20,7 +20,7 @@ function leggNoklerPaaLedetekster(data: object) {
 	return tekster;
 }
 
-function* hentTeksterSaga(): SagaIterator {
+function* hentTeksterSaga(): any {
 	try {
 		yield put(henterTekster());
 		// TODO: Burde lage egen funksjon som holder på url-string

--- a/web/src/frontend/src/nav-soknad/redux/miljovariabler/miljoVariablerSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/miljovariabler/miljoVariablerSaga.ts
@@ -1,5 +1,4 @@
 import { call, put, takeEvery } from "redux-saga/effects";
-import { SagaIterator } from "redux-saga";
 import { fetchToJson } from "../../../nav-soknad/utils/rest-utils";
 import { MiljovariablerActionTypeKeys } from "./miljovariablerTypes";
 import {
@@ -8,7 +7,7 @@ import {
 } from "./miljovariablerActions";
 import { loggFeil } from "../../../nav-soknad/redux/navlogger/navloggerActions";
 
-function* hentMiljovariablerSaga(): SagaIterator {
+export function* hentMiljovariablerSaga(): any {
 	try {
 		yield put(henterMiljovariabler());
 		const response = yield call(fetchToJson, "informasjon/miljovariabler");
@@ -20,7 +19,7 @@ function* hentMiljovariablerSaga(): SagaIterator {
 	}
 }
 
-function* miljovariablerSaga(): SagaIterator {
+function* miljovariablerSaga(): any {
 	yield takeEvery(MiljovariablerActionTypeKeys.INIT, hentMiljovariablerSaga);
 }
 

--- a/web/src/frontend/src/nav-soknad/redux/reduxTypes.ts
+++ b/web/src/frontend/src/nav-soknad/redux/reduxTypes.ts
@@ -16,6 +16,7 @@ import {OpplysningerModel} from "./okonomiskeOpplysninger/opplysningerTypes";
 import {FilState} from "./fil/filTypes";
 import {NavEnhet} from "../../digisos/skjema/personopplysninger/adresse/AdresseTypes";
 import {EttersendelseState} from "./ettersendelse/ettersendelseTypes";
+import {AuthenticationState} from "./authentication/authenticationTypes";
 
 export * from "./fakta/faktaActionTypes";
 export * from "./valideringActionTypes";
@@ -44,7 +45,8 @@ export interface SoknadAppState {
     init: InitState;
     mockData: MockState;
     okonomiskeOpplysninger: OpplysningerModel;
-    filopplasting: FilState
+    filopplasting: FilState;
+    authentication: AuthenticationState;
 }
 
 export interface SoknadState {

--- a/web/src/frontend/src/nav-soknad/redux/tilgang/tilgangSaga.ts
+++ b/web/src/frontend/src/nav-soknad/redux/tilgang/tilgangSaga.ts
@@ -7,7 +7,7 @@ import {
 	hentTilgangFeilet
 } from "./tilgangActions";
 
-function* hentTilgangSaga(): IterableIterator<any> {
+export function* hentTilgangSaga(): any {
 	try {
 		yield put(henterTilgang());
 		const response: TilgangApiResponse = yield call(

--- a/web/src/frontend/src/nav-soknad/utils/rest-utils.ts
+++ b/web/src/frontend/src/nav-soknad/utils/rest-utils.ts
@@ -1,5 +1,8 @@
 /* tslint:disable */
 import {REST_FEIL} from "../types/restFeilTypes";
+import {put} from "redux-saga/effects";
+import {push} from "react-router-redux";
+import {Sider} from "../redux/navigasjon/navigasjonTypes";
 import {erMockMiljoEllerDev} from "./index";
 
 export function erDev(): boolean {
@@ -41,6 +44,17 @@ function getAbsoluteApiUrl() {
 
 function determineCredentialsParameter() {
     return location.origin.indexOf("nais.oera") || erDev() || "heroku" ? "include" : "same-origin";
+}
+
+export function getRedirectPathname(): string {
+    return '/soknadsosialhjelp/link';
+}
+
+export function getRedirectPath(): string {
+    const currentOrigin = window.location.origin;
+    const gotoParameter = "?goto=" + window.location.pathname;
+    const redirectPath = currentOrigin + getRedirectPathname() + gotoParameter;
+    return '?redirect=' + redirectPath;
 }
 
 function getServletBaseUrl(): string {
@@ -222,6 +236,20 @@ export function toJson<T>(response: Response): Promise<T> {
 }
 
 function sjekkStatuskode(response: Response) {
+    const AUTH_LINK_VISITED = "sosialhjelpSoknadAuthLinkVisited";
+
+    if (response.status === 401){
+        if(window.location.pathname !== getRedirectPathname()){
+            if (!window[AUTH_LINK_VISITED]) {
+                response.json().then(r => {
+                    window.location.href = r.loginUrl + getRedirectPath();
+                });
+            }
+        } else {
+            put(push(Sider.SERVERFEIL));
+        }
+        return response;
+    }
     if (response.status >= 200 && response.status < 300) {
         return response;
     }

--- a/web/src/frontend/src/rootSaga.ts
+++ b/web/src/frontend/src/rootSaga.ts
@@ -14,6 +14,7 @@ import vedleggSaga from "./nav-soknad/redux/vedlegg/vedleggSaga";
 import ettersendelseSaga from "./nav-soknad/redux/ettersendelse/ettersendelseSaga";
 import filSaga from "./nav-soknad/redux/fil/filSaga";
 import opplysningerSaga from "./nav-soknad/redux/okonomiskeOpplysninger/opplysningerSaga";
+import authenticationSaga from "./nav-soknad/redux/authentication/authenticationSaga";
 
 export default function* rootSaga() {
 	yield all([
@@ -32,5 +33,6 @@ export default function* rootSaga() {
 		vedleggSaga(),
 		opplysningerSaga(),
 		ettersendelseSaga(),
+		authenticationSaga(),
 	]);
 }

--- a/web/src/main/resources/webapp/WEB-INF/web.xml
+++ b/web/src/main/resources/webapp/WEB-INF/web.xml
@@ -29,6 +29,7 @@
         <url-pattern>/mock/*</url-pattern>
         <url-pattern>/mock-login/*</url-pattern>
         <url-pattern>/undersokelse/*</url-pattern>
+        <url-pattern>/link</url-pattern>
     </filter-mapping>
 
     <servlet>
@@ -45,6 +46,7 @@
         <url-pattern>/informasjon/*</url-pattern>
         <url-pattern>/bosted/*</url-pattern>
         <url-pattern>/kvittering/*</url-pattern>
+        <url-pattern>/link</url-pattern>
         <url-pattern>/mock/*</url-pattern>
         <url-pattern>/mock-login/*</url-pattern>
         <url-pattern>/undersokelse/*</url-pattern>


### PR DESCRIPTION
Har dratt inn alt fra den gamle 1060-branchen, utenom det som lå i **IntlProvider**.
Det ser ut som koden fungerer både uten oidc (da sender aldri server 401) og med oidc.
Denne kan altså merges til master etter test og muligens feilretting.