### PR TITLE
Bruk npmjs lokalt og på Jenkins

### DIFF
--- a/web/src/frontend/.npmrc
+++ b/web/src/frontend/.npmrc
@@ -1,2 +1,2 @@
 strict-ssl=false
-registry=https://repo.adeo.no/repository/npm-public/
+registry=https://registry.npmjs.org/

--- a/web/src/frontend/package-lock.json
+++ b/web/src/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "requires": {
         "@babel/highlight": "^7.0.0"
@@ -14,7 +14,7 @@
     },
     "@babel/core": {
       "version": "7.4.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/core/-/core-7.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
       "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -35,7 +35,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -43,7 +43,7 @@
         },
         "json5": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/json5/-/json5-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
           "requires": {
             "minimist": "^1.2.0"
@@ -51,17 +51,17 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -69,14 +69,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "@babel/generator": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/generator/-/generator-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
       "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "requires": {
         "@babel/types": "^7.4.4",
@@ -88,14 +88,14 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "requires": {
         "@babel/types": "^7.0.0"
@@ -103,7 +103,7 @@
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.1.0",
@@ -112,7 +112,7 @@
     },
     "@babel/helper-builder-react-jsx": {
       "version": "7.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
       "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
       "requires": {
         "@babel/types": "^7.3.0",
@@ -121,7 +121,7 @@
     },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
       "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
@@ -131,7 +131,7 @@
     },
     "@babel/helper-create-class-features-plugin": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz",
       "integrity": "sha512-UbBHIa2qeAGgyiNR9RszVF7bUHEdgS4JAUNT8SiqrAN6YJVxlOxeLr5pBzb5kan302dejJ9nla4RyKcR1XT6XA==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -144,7 +144,7 @@
     },
     "@babel/helper-define-map": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
       "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -154,7 +154,7 @@
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "requires": {
         "@babel/traverse": "^7.1.0",
@@ -163,7 +163,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
@@ -173,7 +173,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "requires": {
         "@babel/types": "^7.0.0"
@@ -181,7 +181,7 @@
     },
     "@babel/helper-hoist-variables": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
       "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
       "requires": {
         "@babel/types": "^7.4.4"
@@ -189,7 +189,7 @@
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "requires": {
         "@babel/types": "^7.0.0"
@@ -197,7 +197,7 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "requires": {
         "@babel/types": "^7.0.0"
@@ -205,7 +205,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
       "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -218,7 +218,7 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "requires": {
         "@babel/types": "^7.0.0"
@@ -226,12 +226,12 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
       "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
       "requires": {
         "lodash": "^4.17.11"
@@ -239,7 +239,7 @@
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -251,7 +251,7 @@
     },
     "@babel/helper-replace-supers": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
       "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -262,7 +262,7 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "requires": {
         "@babel/template": "^7.1.0",
@@ -271,7 +271,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "requires": {
         "@babel/types": "^7.4.4"
@@ -279,7 +279,7 @@
     },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -290,7 +290,7 @@
     },
     "@babel/helpers": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/helpers/-/helpers-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
       "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
       "requires": {
         "@babel/template": "^7.4.4",
@@ -300,7 +300,7 @@
     },
     "@babel/highlight": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/highlight/-/highlight-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "requires": {
         "chalk": "^2.0.0",
@@ -310,12 +310,12 @@
     },
     "@babel/parser": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/parser/-/parser-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
       "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
       "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -325,7 +325,7 @@
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
       "integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.4.0",
@@ -334,7 +334,7 @@
     },
     "@babel/plugin-proposal-decorators": {
       "version": "7.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz",
       "integrity": "sha512-d08TLmXeK/XbgCo7ZeZ+JaeZDtDai/2ctapTRsWWkkmy7G/cqz8DQN/HlWG7RR4YmfXxmExsbU3SuCjlM7AtUg==",
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.4.0",
@@ -344,7 +344,7 @@
     },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
       "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -353,7 +353,7 @@
     },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
       "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -362,7 +362,7 @@
     },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -371,7 +371,7 @@
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
       "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -381,7 +381,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -389,7 +389,7 @@
     },
     "@babel/plugin-syntax-decorators": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
       "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -397,7 +397,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -405,7 +405,7 @@
     },
     "@babel/plugin-syntax-flow": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
       "integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -413,7 +413,7 @@
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -421,7 +421,7 @@
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -429,7 +429,7 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -437,7 +437,7 @@
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -445,7 +445,7 @@
     },
     "@babel/plugin-syntax-typescript": {
       "version": "7.3.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
       "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -453,7 +453,7 @@
     },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -461,7 +461,7 @@
     },
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
       "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -471,7 +471,7 @@
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -479,7 +479,7 @@
     },
     "@babel/plugin-transform-block-scoping": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
       "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -488,7 +488,7 @@
     },
     "@babel/plugin-transform-classes": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
       "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -503,7 +503,7 @@
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -511,7 +511,7 @@
     },
     "@babel/plugin-transform-destructuring": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
       "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -519,7 +519,7 @@
     },
     "@babel/plugin-transform-dotall-regex": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
       "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -529,7 +529,7 @@
     },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
       "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -537,7 +537,7 @@
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
@@ -546,7 +546,7 @@
     },
     "@babel/plugin-transform-flow-strip-types": {
       "version": "7.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz",
       "integrity": "sha512-C4ZVNejHnfB22vI2TYN4RUp2oCmq6cSEAg4RygSvYZUECRqUu9O4PMEMNJ4wsemaRGg27BbgYctG4BZh+AgIHw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -555,7 +555,7 @@
     },
     "@babel/plugin-transform-for-of": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
       "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -563,7 +563,7 @@
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
       "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -572,7 +572,7 @@
     },
     "@babel/plugin-transform-literals": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -580,7 +580,7 @@
     },
     "@babel/plugin-transform-member-expression-literals": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
       "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -588,7 +588,7 @@
     },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
       "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
@@ -597,7 +597,7 @@
     },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
       "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
@@ -607,7 +607,7 @@
     },
     "@babel/plugin-transform-modules-systemjs": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
       "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
@@ -616,7 +616,7 @@
     },
     "@babel/plugin-transform-modules-umd": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
       "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
@@ -625,7 +625,7 @@
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
       "integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
       "requires": {
         "regexp-tree": "^0.1.6"
@@ -633,7 +633,7 @@
     },
     "@babel/plugin-transform-new-target": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
       "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -641,7 +641,7 @@
     },
     "@babel/plugin-transform-object-super": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
       "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -650,7 +650,7 @@
     },
     "@babel/plugin-transform-parameters": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
       "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
       "requires": {
         "@babel/helper-call-delegate": "^7.4.4",
@@ -660,7 +660,7 @@
     },
     "@babel/plugin-transform-property-literals": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
       "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -668,7 +668,7 @@
     },
     "@babel/plugin-transform-react-constant-elements": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
       "integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -677,7 +677,7 @@
     },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
       "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -685,7 +685,7 @@
     },
     "@babel/plugin-transform-react-jsx": {
       "version": "7.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
       "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.3.0",
@@ -695,7 +695,7 @@
     },
     "@babel/plugin-transform-react-jsx-self": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
       "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -704,7 +704,7 @@
     },
     "@babel/plugin-transform-react-jsx-source": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
       "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -713,7 +713,7 @@
     },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
       "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
       "requires": {
         "regenerator-transform": "^0.14.0"
@@ -721,7 +721,7 @@
     },
     "@babel/plugin-transform-reserved-words": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
       "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -729,7 +729,7 @@
     },
     "@babel/plugin-transform-runtime": {
       "version": "7.4.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
       "integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -740,7 +740,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -750,7 +750,7 @@
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -758,7 +758,7 @@
     },
     "@babel/plugin-transform-spread": {
       "version": "7.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
       "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -766,7 +766,7 @@
     },
     "@babel/plugin-transform-sticky-regex": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -775,7 +775,7 @@
     },
     "@babel/plugin-transform-template-literals": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
       "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -784,7 +784,7 @@
     },
     "@babel/plugin-transform-typeof-symbol": {
       "version": "7.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -792,7 +792,7 @@
     },
     "@babel/plugin-transform-typescript": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz",
       "integrity": "sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -801,7 +801,7 @@
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
       "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -811,7 +811,7 @@
     },
     "@babel/preset-env": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/preset-env/-/preset-env-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
       "integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -866,7 +866,7 @@
     },
     "@babel/preset-react": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/preset-react/-/preset-react-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
       "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -878,7 +878,7 @@
     },
     "@babel/preset-typescript": {
       "version": "7.3.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
       "integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -887,7 +887,7 @@
     },
     "@babel/runtime": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/runtime/-/runtime-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
       "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -895,14 +895,14 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.13.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
           "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
     "@babel/template": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/template/-/template-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -912,7 +912,7 @@
     },
     "@babel/traverse": {
       "version": "7.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/traverse/-/traverse-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
       "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -928,7 +928,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -936,14 +936,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "@babel/types": {
       "version": "7.4.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/types/-/types-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "requires": {
         "esutils": "^2.0.2",
@@ -953,7 +953,7 @@
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
       "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
       "requires": {
         "exec-sh": "^0.3.2",
@@ -962,14 +962,14 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "@craco/craco": {
       "version": "5.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@craco/craco/-/craco-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-5.2.3.tgz",
       "integrity": "sha512-fV4BGsARe6W723rDsmrQfezZVT52wI+GJGmK7Ec8DhqzWgMVaULVwqdDm8CIdhKBUzltEs/YcZmig6jh8lvdLQ==",
       "dev": true,
       "requires": {
@@ -980,27 +980,27 @@
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@csstools/normalize.css": {
       "version": "9.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@csstools/normalize.css/-/normalize.css-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-9.0.1.tgz",
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
     "@hapi/address": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@hapi/address/-/address-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
       "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
     },
     "@hapi/hoek": {
       "version": "6.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@hapi/hoek/-/hoek-6.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
       "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
     },
     "@hapi/joi": {
       "version": "15.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@hapi/joi/-/joi-15.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
       "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
       "requires": {
         "@hapi/address": "2.x.x",
@@ -1011,12 +1011,12 @@
     },
     "@hapi/marker": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@hapi/marker/-/marker-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
       "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
     },
     "@hapi/topo": {
       "version": "3.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@hapi/topo/-/topo-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
       "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
       "requires": {
         "@hapi/hoek": "8.x.x"
@@ -1024,14 +1024,14 @@
       "dependencies": {
         "@hapi/hoek": {
           "version": "8.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@hapi/hoek/-/hoek-8.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.1.tgz",
           "integrity": "sha512-cctMYH5RLbElaUpZn3IJaUj9QNQD8iXDnl7xNY6KB1aFD2ciJrwpo3kvZowIT75uA+silJFDnSR2kGakALUymg=="
         }
       }
     },
     "@jest/console": {
       "version": "24.7.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/console/-/console-24.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
       "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
       "requires": {
         "@jest/source-map": "^24.3.0",
@@ -1041,7 +1041,7 @@
     },
     "@jest/core": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/core/-/core-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
       "integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
       "requires": {
         "@jest/console": "^24.7.1",
@@ -1075,12 +1075,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -1090,7 +1090,7 @@
     },
     "@jest/environment": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/environment/-/environment-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
       "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
       "requires": {
         "@jest/fake-timers": "^24.8.0",
@@ -1101,7 +1101,7 @@
     },
     "@jest/fake-timers": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
       "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -1111,7 +1111,7 @@
     },
     "@jest/reporters": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/reporters/-/reporters-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
       "integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
       "requires": {
         "@jest/environment": "^24.8.0",
@@ -1139,7 +1139,7 @@
       "dependencies": {
         "jest-resolve": {
           "version": "24.8.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve/-/jest-resolve-24.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
           "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
           "requires": {
             "@jest/types": "^24.8.0",
@@ -1153,7 +1153,7 @@
     },
     "@jest/source-map": {
       "version": "24.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/source-map/-/source-map-24.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
       "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
       "requires": {
         "callsites": "^3.0.0",
@@ -1163,14 +1163,14 @@
       "dependencies": {
         "callsites": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/callsites/-/callsites-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
           "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         }
       }
     },
     "@jest/test-result": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/test-result/-/test-result-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
       "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
       "requires": {
         "@jest/console": "^24.7.1",
@@ -1180,7 +1180,7 @@
     },
     "@jest/test-sequencer": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
       "integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
       "requires": {
         "@jest/test-result": "^24.8.0",
@@ -1191,7 +1191,7 @@
     },
     "@jest/transform": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/transform/-/transform-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
       "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
       "requires": {
         "@babel/core": "^7.1.0",
@@ -1213,7 +1213,7 @@
     },
     "@jest/types": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@jest/types/-/types-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
       "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1223,7 +1223,7 @@
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
         "call-me-maybe": "^1.0.1",
@@ -1232,12 +1232,12 @@
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@redux-saga/core": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@redux-saga/core/-/core-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.0.3.tgz",
       "integrity": "sha512-zf8h5N0oTzaNeSMxOWH9GJMB9IRSM8JubDsrZVsvVltXjzFFSR8DNt7tbPoRJUK0hFfQB1it+bL+dEMWpD7wXA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -1252,12 +1252,12 @@
     },
     "@redux-saga/deferred": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@redux-saga/deferred/-/deferred-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.0.1.tgz",
       "integrity": "sha512-+gW5xQ93QXOOmRLAmX8x2Hx1HpbTG6CM6+HcdTSbJovh4uMWaGyeDECnqXSt8QqA/ja3s2nqYXLqXFKepIQ1hw=="
     },
     "@redux-saga/delay-p": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@redux-saga/delay-p/-/delay-p-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.0.1.tgz",
       "integrity": "sha512-0SnNDyDLUyB4NThtptAwiprNOnbCNhoed/Rp5JwS7SB+a/AdWynVgg/E6BmjsggLFNr07KW0bzn05tsPRBuU7Q==",
       "requires": {
         "@redux-saga/symbols": "^1.0.1"
@@ -1265,7 +1265,7 @@
     },
     "@redux-saga/is": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@redux-saga/is/-/is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.0.2.tgz",
       "integrity": "sha512-WnaUOwYvPK2waWjzebT4uhL8zY76XNkzzpJ2EQJe8bN1tByvAjvT7MuJZTSshOhdHL5PsRO0MsH224XIXBJidQ==",
       "requires": {
         "@redux-saga/symbols": "^1.0.1",
@@ -1274,57 +1274,57 @@
     },
     "@redux-saga/symbols": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@redux-saga/symbols/-/symbols-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.0.1.tgz",
       "integrity": "sha512-akKkzcVnb1RzJaZV2LQFbi51abvdICMuAKwwLoCjjxLbLAGIw9EJxk5ucNnWSSCEsoEQMeol5tkAcK+Xzuv1Bg=="
     },
     "@redux-saga/types": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@redux-saga/types/-/types-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",
       "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
       "integrity": "sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig=="
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz",
       "integrity": "sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ=="
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz",
       "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w=="
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
       "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w=="
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "4.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.0.tgz",
       "integrity": "sha512-3eI17Pb3jlg3oqV4Tie069n1SelYKBUpI90txDcnBWk4EGFW+YQGyQjy6iuJAReH0RnpUJ9jUExrt/xniGvhqw=="
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
       "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w=="
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
       "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw=="
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
       "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw=="
     },
     "@svgr/babel-preset": {
       "version": "4.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/babel-preset/-/babel-preset-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.3.0.tgz",
       "integrity": "sha512-Lgy1RJiZumGtv6yJroOxzFuL64kG/eIcivJQ7y9ljVWL+0QXvFz4ix1xMrmjMD+rpJWwj50ayCIcFelevG/XXg==",
       "requires": {
         "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
@@ -1339,7 +1339,7 @@
     },
     "@svgr/core": {
       "version": "4.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/core/-/core-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-4.3.0.tgz",
       "integrity": "sha512-Ycu1qrF5opBgKXI0eQg3ROzupalCZnSDETKCK/3MKN4/9IEmt3jPX/bbBjftklnRW+qqsCEpO0y/X9BTRw2WBg==",
       "requires": {
         "@svgr/plugin-jsx": "^4.3.0",
@@ -1349,7 +1349,7 @@
     },
     "@svgr/hast-util-to-babel-ast": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.2.0.tgz",
       "integrity": "sha512-IvAeb7gqrGB5TH9EGyBsPrMRH/QCzIuAkLySKvH2TLfLb2uqk98qtJamordRQTpHH3e6TORfBXoTo7L7Opo/Ow==",
       "requires": {
         "@babel/types": "^7.4.0"
@@ -1357,7 +1357,7 @@
     },
     "@svgr/plugin-jsx": {
       "version": "4.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/plugin-jsx/-/plugin-jsx-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-4.3.0.tgz",
       "integrity": "sha512-0ab8zJdSOTqPfjZtl89cjq2IOmXXUYV3Fs7grLT9ur1Al3+x3DSp2+/obrYKUGbQUnLq96RMjSZ7Icd+13vwlQ==",
       "requires": {
         "@babel/core": "^7.4.3",
@@ -1370,7 +1370,7 @@
     },
     "@svgr/plugin-svgo": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/plugin-svgo/-/plugin-svgo-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-4.2.0.tgz",
       "integrity": "sha512-zUEKgkT172YzHh3mb2B2q92xCnOAMVjRx+o0waZ1U50XqKLrVQ/8dDqTAtnmapdLsGurv8PSwenjLCUpj6hcvw==",
       "requires": {
         "cosmiconfig": "^5.2.0",
@@ -1380,7 +1380,7 @@
     },
     "@svgr/webpack": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@svgr/webpack/-/webpack-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.1.0.tgz",
       "integrity": "sha512-d09ehQWqLMywP/PT/5JvXwPskPK9QCXUjiSkAHehreB381qExXf5JFCBWhfEyNonRbkIneCeYM99w+Ud48YIQQ==",
       "requires": {
         "@babel/core": "^7.1.6",
@@ -1395,7 +1395,7 @@
     },
     "@types/babel__core": {
       "version": "7.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/babel__core/-/babel__core-7.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
       "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1407,7 +1407,7 @@
     },
     "@types/babel__generator": {
       "version": "7.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
       "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
       "requires": {
         "@babel/types": "^7.0.0"
@@ -1415,7 +1415,7 @@
     },
     "@types/babel__template": {
       "version": "7.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
       "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1424,7 +1424,7 @@
     },
     "@types/babel__traverse": {
       "version": "7.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
       "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1432,7 +1432,7 @@
     },
     "@types/cheerio": {
       "version": "0.22.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/cheerio/-/cheerio-0.22.11.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.11.tgz",
       "integrity": "sha512-x0X3kPbholdJZng9wDMhb2swvUi3UYRNAuWAmIPIWlfgAJZp//cql/qblE7181Mg7SjWVwq6ldCPCLn5AY/e7w==",
       "dev": true,
       "requires": {
@@ -1441,19 +1441,19 @@
     },
     "@types/classnames": {
       "version": "2.2.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/classnames/-/classnames-2.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.8.tgz",
       "integrity": "sha512-3UrLzPnz8u+MMXuJTF++389IfLSQUbl5F3ry9WCxva0BKG5H/oo5NuPRXk+HrpPU1+5pVHSWhnVWRzIaFQ7QuQ==",
       "dev": true
     },
     "@types/cuid": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/cuid/-/cuid-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cuid/-/cuid-1.3.0.tgz",
       "integrity": "sha1-ILDgDKVV31ZIZrxS0uJRv5DIjbc=",
       "dev": true
     },
     "@types/enzyme": {
       "version": "3.9.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/enzyme/-/enzyme-3.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.9.4.tgz",
       "integrity": "sha512-bQcwt5gcKnekrbci4hcapfE2J6rkkFbHM1l4VobLtSl4ogOfj0lvSxrdS6FftCakmJqqPBqdQCwb5KnlivL6SQ==",
       "dev": true,
       "requires": {
@@ -1463,7 +1463,7 @@
     },
     "@types/enzyme-adapter-react-16": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.5.tgz",
       "integrity": "sha512-K7HLFTkBDN5RyRmU90JuYt8OWEY2iKUn43SDWEoBOXd/PowUWjLZ3Q6qMBiQuZeFYK/TOstaZxsnI0fXoAfLpg==",
       "dev": true,
       "requires": {
@@ -1472,13 +1472,13 @@
     },
     "@types/history": {
       "version": "4.7.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/history/-/history-4.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.2.tgz",
       "integrity": "sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==",
       "dev": true
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "dev": true,
       "requires": {
@@ -1488,12 +1488,12 @@
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
       "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
       "requires": {
         "@types/istanbul-lib-coverage": "*"
@@ -1501,7 +1501,7 @@
     },
     "@types/istanbul-reports": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
       "requires": {
         "@types/istanbul-lib-coverage": "*",
@@ -1510,7 +1510,7 @@
     },
     "@types/jest": {
       "version": "24.0.13",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/jest/-/jest-24.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.13.tgz",
       "integrity": "sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==",
       "dev": true,
       "requires": {
@@ -1519,29 +1519,29 @@
     },
     "@types/jest-diff": {
       "version": "20.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/jest-diff/-/jest-diff-20.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
     "@types/node": {
       "version": "12.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/node/-/node-12.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
       "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw==",
       "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
       "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
     },
     "@types/q": {
       "version": "1.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/q/-/q-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
       "version": "16.8.19",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react/-/react-16.8.19.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.19.tgz",
       "integrity": "sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==",
       "dev": true,
       "requires": {
@@ -1551,7 +1551,7 @@
     },
     "@types/react-document-title": {
       "version": "2.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-document-title/-/react-document-title-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-document-title/-/react-document-title-2.0.3.tgz",
       "integrity": "sha512-d37BZ9KzPQ7HJ9ILeAkSjJLB2EhiPxCbQduNSyS6BmwyZXcRstme2EwfmpzHwdkqoGfOwpbxMtSaO6MrIRQ0MQ==",
       "dev": true,
       "requires": {
@@ -1560,7 +1560,7 @@
     },
     "@types/react-dom": {
       "version": "16.8.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-dom/-/react-dom-16.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.4.tgz",
       "integrity": "sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==",
       "dev": true,
       "requires": {
@@ -1569,7 +1569,7 @@
     },
     "@types/react-inlinesvg": {
       "version": "0.8.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-inlinesvg/-/react-inlinesvg-0.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-inlinesvg/-/react-inlinesvg-0.8.1.tgz",
       "integrity": "sha512-pONmeCNqot4diXLhxb+jajDWX57rH/JmMu9H4NQWNMl5WUHAHmcrOfDfB05IgYBfRUX1Cvyjl9EZzKHxSxZpAA==",
       "requires": {
         "@types/react": "*"
@@ -1577,7 +1577,7 @@
       "dependencies": {
         "@types/react": {
           "version": "16.8.22",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@types/react/-/react-16.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.22.tgz",
           "integrity": "sha512-C3O1yVqk4sUXqWyx0wlys76eQfhrQhiDhDlHBrjER76lR2S2Agiid/KpOU9oCqj1dISStscz7xXz1Cg8+sCQeA==",
           "requires": {
             "@types/prop-types": "*",
@@ -1588,13 +1588,13 @@
     },
     "@types/react-intl": {
       "version": "2.3.18",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-intl/-/react-intl-2.3.18.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-intl/-/react-intl-2.3.18.tgz",
       "integrity": "sha512-DVNJs49zUxKRZng8VuILE886Yihdsf3yLr5vHk9zJrmF8SyRSK3sxNSvikAKxNkv9hX55XBTJShz6CkJnbNjgg==",
       "dev": true
     },
     "@types/react-redux": {
       "version": "7.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-redux/-/react-redux-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.1.tgz",
       "integrity": "sha512-owqNahzE8en/jR4NtrUJDJya3tKru7CIEGSRL/pVS84LtSCdSoT7qZTkrbBd3S4Lp11sAp+7LsvxIeONJVKMnw==",
       "dev": true,
       "requires": {
@@ -1606,7 +1606,7 @@
     },
     "@types/react-router": {
       "version": "5.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-router/-/react-router-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.0.2.tgz",
       "integrity": "sha512-sdMN284GEOcqDEMS/hE/XD06Abw2fws30+xkZf3C9cSRcWopiv/HDTmunYI7DKLYKVRaWFkq1lkuJ6qeYu0E7A==",
       "dev": true,
       "requires": {
@@ -1616,7 +1616,7 @@
     },
     "@types/react-router-dom": {
       "version": "4.3.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-router-dom/-/react-router-dom-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.3.4.tgz",
       "integrity": "sha512-xrwaWHpnxKk/TTRe7pmoGy3E4SyF/ojFqNfFJacw7OLdfLXRvGfk4r/XePVaZNVfeJzL8fcnNilPN7xOdJ/vGw==",
       "dev": true,
       "requires": {
@@ -1627,7 +1627,7 @@
     },
     "@types/react-scroll": {
       "version": "1.5.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/react-scroll/-/react-scroll-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-scroll/-/react-scroll-1.5.4.tgz",
       "integrity": "sha512-EYJt9wDvyrcDZpZqI19eb2UlAzCoXBeoFu3yMkrBDC8zkwFXOhb8lv3tD9V9UAqptora096M7qWYktsWq1guEg==",
       "dev": true,
       "requires": {
@@ -1636,7 +1636,7 @@
     },
     "@types/redux-logger": {
       "version": "3.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/redux-logger/-/redux-logger-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.7.tgz",
       "integrity": "sha512-oV9qiCuowhVR/ehqUobWWkXJjohontbDGLV88Be/7T4bqMQ3kjXwkFNL7doIIqlbg3X2PC5WPziZ8/j/QHNQ4A==",
       "dev": true,
       "requires": {
@@ -1645,7 +1645,7 @@
       "dependencies": {
         "redux": {
           "version": "3.7.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/redux/-/redux-3.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
           "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
           "dev": true,
           "requires": {
@@ -1659,17 +1659,17 @@
     },
     "@types/stack-utils": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
     },
     "@types/unist": {
       "version": "2.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/unist/-/unist-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/vfile": {
       "version": "3.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/vfile/-/vfile-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
       "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
       "requires": {
         "@types/node": "*",
@@ -1679,14 +1679,14 @@
       "dependencies": {
         "@types/node": {
           "version": "12.0.10",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@types/node/-/node-12.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
           "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
         }
       }
     },
     "@types/vfile-message": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
       "requires": {
         "@types/node": "*",
@@ -1695,19 +1695,19 @@
       "dependencies": {
         "@types/node": {
           "version": "12.0.10",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@types/node/-/node-12.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
           "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
         }
       }
     },
     "@types/yargs": {
       "version": "12.0.12",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@types/yargs/-/yargs-12.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
       "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.6.0.tgz",
       "integrity": "sha512-U224c29E2lo861TQZs6GSmyC0OYeRNg6bE9UVIiFBxN2MlA0nq2dCrgIVyyRbC05UOcrgf2Wk/CF2gGOPQKUSQ==",
       "requires": {
         "@typescript-eslint/parser": "1.6.0",
@@ -1718,7 +1718,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@typescript-eslint/parser/-/parser-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.6.0.tgz",
       "integrity": "sha512-VB9xmSbfafI+/kI4gUK3PfrkGmrJQfh0N4EScT1gZXSZyUxpsBirPL99EWZg9MmPG0pzq/gMtgkk7/rAHj4aQw==",
       "requires": {
         "@typescript-eslint/typescript-estree": "1.6.0",
@@ -1728,7 +1728,7 @@
     },
     "@typescript-eslint/typescript-estree": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz",
       "integrity": "sha512-A4CanUwfaG4oXobD5y7EXbsOHjCwn8tj1RDd820etpPAjH+Icjc2K9e/DQM1Hac5zH2BSy+u6bjvvF2wwREvYA==",
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -1737,14 +1737,14 @@
       "dependencies": {
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/semver/-/semver-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         }
       }
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
       "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
       "requires": {
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -1754,22 +1754,22 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
       "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
       "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
       "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
       "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
       "requires": {
         "@webassemblyjs/wast-printer": "1.8.5"
@@ -1777,12 +1777,12 @@
     },
     "@webassemblyjs/helper-fsm": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
       "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
       "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1791,12 +1791,12 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
       "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
       "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1807,7 +1807,7 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
       "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
@@ -1815,7 +1815,7 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
       "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
       "requires": {
         "@xtuc/long": "4.2.2"
@@ -1823,12 +1823,12 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
       "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
       "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1843,7 +1843,7 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
       "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1855,7 +1855,7 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
       "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1866,7 +1866,7 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
       "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1879,7 +1879,7 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
       "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1892,7 +1892,7 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
       "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -1902,22 +1902,22 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@xtuc/long/-/long-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "abab": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/abab/-/abab-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/accepts/-/accepts-1.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
         "mime-types": "~2.1.24",
@@ -1926,17 +1926,17 @@
     },
     "acorn": {
       "version": "6.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/acorn/-/acorn-6.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
       "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "acorn-globals": {
       "version": "4.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/acorn-globals/-/acorn-globals-4.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
       "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
       "requires": {
         "acorn": "^6.0.1",
@@ -1945,22 +1945,22 @@
     },
     "acorn-jsx": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
     },
     "acorn-walk": {
       "version": "6.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "address": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/address/-/address-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
     "airbnb-prop-types": {
       "version": "2.13.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
       "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
       "requires": {
         "array.prototype.find": "^2.0.4",
@@ -1977,7 +1977,7 @@
     },
     "ajv": {
       "version": "6.10.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ajv/-/ajv-6.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -1988,42 +1988,42 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
       "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "ansi-colors": {
       "version": "3.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ansi-html/-/ansi-html-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
@@ -2031,7 +2031,7 @@
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/anymatch/-/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
         "micromatch": "^3.1.4",
@@ -2040,7 +2040,7 @@
       "dependencies": {
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -2050,12 +2050,12 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -2063,7 +2063,7 @@
     },
     "aria-query": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/aria-query/-/aria-query-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "requires": {
         "ast-types-flow": "0.0.7",
@@ -2072,37 +2072,37 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-filter/-/array-filter-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "array-flatten": {
       "version": "2.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-flatten/-/array-flatten-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
         "define-properties": "^1.1.2",
@@ -2111,17 +2111,17 @@
     },
     "array-map": {
       "version": "0.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-map/-/array-map-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
       "version": "0.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-reduce/-/array-reduce-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
         "array-uniq": "^1.0.1"
@@ -2129,17 +2129,17 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.find": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
       "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
       "requires": {
         "define-properties": "^1.1.3",
@@ -2148,7 +2148,7 @@
     },
     "array.prototype.flat": {
       "version": "1.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
       "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
       "requires": {
         "define-properties": "^1.1.2",
@@ -2158,17 +2158,17 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -2176,7 +2176,7 @@
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/asn1.js/-/asn1.js-4.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "^4.0.0",
@@ -2186,7 +2186,7 @@
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/assert/-/assert-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "requires": {
         "object-assign": "^4.1.1",
@@ -2195,12 +2195,12 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -2210,52 +2210,52 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types-flow": {
       "version": "0.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/astral-regex/-/astral-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/async-each/-/async-each-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/async-limiter/-/async-limiter-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autoprefixer": {
       "version": "9.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/autoprefixer/-/autoprefixer-9.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
       "integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
       "requires": {
         "browserslist": "^4.6.1",
@@ -2269,17 +2269,17 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axobject-query": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/axobject-query/-/axobject-query-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
       "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
       "requires": {
         "ast-types-flow": "0.0.7"
@@ -2287,7 +2287,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "^1.1.3",
@@ -2297,17 +2297,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -2319,12 +2319,12 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/js-tokens/-/js-tokens-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2332,14 +2332,14 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "babel-eslint": {
       "version": "10.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
       "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2352,7 +2352,7 @@
       "dependencies": {
         "eslint-scope": {
           "version": "3.7.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
           "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
           "requires": {
             "esrecurse": "^4.1.0",
@@ -2363,7 +2363,7 @@
     },
     "babel-extract-comments": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
       "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
       "requires": {
         "babylon": "^6.18.0"
@@ -2371,7 +2371,7 @@
     },
     "babel-jest": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-jest/-/babel-jest-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
       "integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
       "requires": {
         "@jest/transform": "^24.8.0",
@@ -2385,7 +2385,7 @@
     },
     "babel-loader": {
       "version": "8.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-loader/-/babel-loader-8.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
       "integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
       "requires": {
         "find-cache-dir": "^2.0.0",
@@ -2396,7 +2396,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
       "integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
       "requires": {
         "object.assign": "^4.1.0"
@@ -2404,7 +2404,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "5.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
       "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
       "requires": {
         "find-up": "^3.0.0",
@@ -2414,7 +2414,7 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "24.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
       "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
       "requires": {
         "@types/babel__traverse": "^7.0.6"
@@ -2422,7 +2422,7 @@
     },
     "babel-plugin-macros": {
       "version": "2.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
       "integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
       "requires": {
         "@babel/runtime": "^7.4.2",
@@ -2432,7 +2432,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -2442,17 +2442,17 @@
     },
     "babel-plugin-named-asset-import": {
       "version": "0.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz",
       "integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ=="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "^6.8.0",
@@ -2461,12 +2461,12 @@
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-polyfill": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2476,7 +2476,7 @@
     },
     "babel-preset-jest": {
       "version": "24.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
       "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
@@ -2485,7 +2485,7 @@
     },
     "babel-preset-react-app": {
       "version": "9.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-preset-react-app/-/babel-preset-react-app-9.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.0.tgz",
       "integrity": "sha512-YVsDA8HpAKklhFLJtl9+AgaxrDaor8gGvDFlsg1ByOS0IPGUovumdv4/gJiAnLcDmZmKlH6+9sVOz4NVW7emAg==",
       "requires": {
         "@babel/core": "7.4.3",
@@ -2510,7 +2510,7 @@
       "dependencies": {
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.4.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
           "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
@@ -2519,7 +2519,7 @@
         },
         "@babel/plugin-transform-classes": {
           "version": "7.4.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
           "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -2534,7 +2534,7 @@
         },
         "@babel/plugin-transform-destructuring": {
           "version": "7.4.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
           "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0"
@@ -2542,7 +2542,7 @@
         },
         "@babel/preset-env": {
           "version": "7.4.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@babel/preset-env/-/preset-env-7.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
           "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
           "requires": {
             "@babel/helper-module-imports": "^7.0.0",
@@ -2597,7 +2597,7 @@
         },
         "@babel/runtime": {
           "version": "7.4.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@babel/runtime/-/runtime-7.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
           "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
@@ -2605,14 +2605,14 @@
         },
         "regenerator-runtime": {
           "version": "0.13.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
           "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
         "core-js": "^2.4.0",
@@ -2621,29 +2621,29 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babylon/-/babylon-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "bail": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bail/-/bail-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
       "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "^1.0.1",
@@ -2657,7 +2657,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -2665,7 +2665,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -2673,7 +2673,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -2681,7 +2681,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -2693,17 +2693,17 @@
     },
     "base64-js": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/base64-js/-/base64-js-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -2711,27 +2711,27 @@
     },
     "big.js": {
       "version": "5.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/big.js/-/big.js-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "bluebird": {
       "version": "3.5.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bluebird/-/bluebird-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
       "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bn.js/-/bn.js-4.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
         "bytes": "3.1.0",
@@ -2748,19 +2748,19 @@
       "dependencies": {
         "bytes": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/bytes/-/bytes-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bonjour/-/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
         "array-flatten": "^2.1.0",
@@ -2773,12 +2773,12 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2787,7 +2787,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
         "arr-flatten": "^1.1.0",
@@ -2804,7 +2804,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -2814,17 +2814,17 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
     },
     "browser-resolve": {
       "version": "1.11.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "requires": {
         "resolve": "1.1.7"
@@ -2832,7 +2832,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -2845,7 +2845,7 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -2855,7 +2855,7 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserify-des/-/browserify-des-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -2866,7 +2866,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -2875,7 +2875,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
         "bn.js": "^4.1.1",
@@ -2889,7 +2889,7 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
         "pako": "~1.0.5"
@@ -2897,7 +2897,7 @@
     },
     "browserslist": {
       "version": "4.6.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/browserslist/-/browserslist-4.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
       "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
       "requires": {
         "caniuse-lite": "^1.0.30000975",
@@ -2907,7 +2907,7 @@
     },
     "bser": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bser/-/bser-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
       "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
       "requires": {
         "node-int64": "^0.4.0"
@@ -2915,7 +2915,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -2925,32 +2925,32 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
       "version": "11.3.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cacache/-/cacache-11.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
       "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
       "requires": {
         "bluebird": "^3.5.5",
@@ -2971,7 +2971,7 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "^1.0.0",
@@ -2987,12 +2987,12 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
         "callsites": "^2.0.0"
@@ -3000,7 +3000,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "requires": {
         "caller-callsite": "^2.0.0"
@@ -3008,12 +3008,12 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
         "no-case": "^2.2.0",
@@ -3022,12 +3022,12 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-api": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "requires": {
         "browserslist": "^4.0.0",
@@ -3038,12 +3038,12 @@
     },
     "caniuse-lite": {
       "version": "1.0.30000978",
-      "resolved": "https://repo.adeo.no/repository/npm-public/caniuse-lite/-/caniuse-lite-1.0.30000978.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000978.tgz",
       "integrity": "sha512-H6gK6kxUzG6oAwg/Jal279z8pHw0BzrpZfwo/CA9FFm/vA0l8IhDfkZtepyJNE2Y4V6Dp3P3ubz6czby1/Mgsw=="
     },
     "capture-exit": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/capture-exit/-/capture-exit-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
       "requires": {
         "rsvp": "^4.8.4"
@@ -3051,22 +3051,22 @@
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
       "integrity": "sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g=="
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "ccount": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ccount/-/ccount-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
       "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -3076,12 +3076,12 @@
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/chardet/-/chardet-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "cheerio": {
       "version": "1.0.0-rc.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
       "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "requires": {
         "css-select": "~1.2.0",
@@ -3094,7 +3094,7 @@
     },
     "chokidar": {
       "version": "2.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/chokidar/-/chokidar-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
       "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "requires": {
         "anymatch": "^2.0.0",
@@ -3113,12 +3113,12 @@
     },
     "chownr": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/chownr/-/chownr-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "requires": {
         "tslib": "^1.9.0"
@@ -3126,12 +3126,12 @@
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cipher-base/-/cipher-base-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "^2.0.1",
@@ -3140,7 +3140,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "^3.1.0",
@@ -3151,7 +3151,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -3161,12 +3161,12 @@
     },
     "classnames": {
       "version": "2.2.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/classnames/-/classnames-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-css": {
       "version": "4.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/clean-css/-/clean-css-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "requires": {
         "source-map": "~0.6.0"
@@ -3174,7 +3174,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
         "restore-cursor": "^2.0.0"
@@ -3182,12 +3182,12 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cliui/-/cliui-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
         "string-width": "^2.1.1",
@@ -3197,12 +3197,12 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/clone/-/clone-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "0.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/clone-deep/-/clone-deep-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "requires": {
         "for-own": "^0.1.3",
@@ -3214,7 +3214,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -3224,12 +3224,12 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/coa/-/coa-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "requires": {
         "@types/q": "^1.5.1",
@@ -3239,12 +3239,12 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -3253,7 +3253,7 @@
     },
     "color": {
       "version": "3.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/color/-/color-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "requires": {
         "color-convert": "^1.9.1",
@@ -3262,7 +3262,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
         "color-name": "1.1.3"
@@ -3270,12 +3270,12 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/color-string/-/color-string-1.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
         "color-name": "^1.0.0",
@@ -3284,13 +3284,13 @@
     },
     "colors": {
       "version": "1.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/colors/-/colors-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
       "integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ==",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -3298,32 +3298,32 @@
     },
     "comma-separated-tokens": {
       "version": "1.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
       "integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
     },
     "commander": {
       "version": "2.20.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/commander/-/commander-2.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "common-tags": {
       "version": "1.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/common-tags/-/common-tags-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compressible": {
       "version": "2.0.17",
-      "resolved": "https://repo.adeo.no/repository/npm-public/compressible/-/compressible-2.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
       "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "requires": {
         "mime-db": ">= 1.40.0 < 2"
@@ -3331,7 +3331,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/compression/-/compression-1.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "requires": {
         "accepts": "~1.3.5",
@@ -3345,12 +3345,12 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -3361,17 +3361,17 @@
     },
     "confusing-browser-globals": {
       "version": "1.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
       "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ=="
     },
     "connect-history-api-fallback": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "connected-react-router": {
       "version": "6.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/connected-react-router/-/connected-react-router-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.4.0.tgz",
       "integrity": "sha512-RZRLD7qUz9OdmCn0JkW7pOiUsR7v9NtqnYKfqrxXsfO2ozMLR2/MjHaSPpdbMr4VE5TY6MwzAXUSkheN2ldqug==",
       "requires": {
         "immutable": "^3.8.1",
@@ -3381,7 +3381,7 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
         "date-now": "^0.1.4"
@@ -3389,17 +3389,17 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/content-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "requires": {
         "safe-buffer": "5.1.2"
@@ -3407,12 +3407,12 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3420,17 +3420,17 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cookie/-/cookie-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "requires": {
         "aproba": "^1.1.1",
@@ -3443,17 +3443,17 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
       "version": "2.6.9",
-      "resolved": "https://repo.adeo.no/repository/npm-public/core-js/-/core-js-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
       "version": "3.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/core-js-compat/-/core-js-compat-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
       "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
       "requires": {
         "browserslist": "^4.6.2",
@@ -3462,25 +3462,25 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/semver/-/semver-6.1.2.tgz",
-          "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ=="
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.3.tgz",
+          "integrity": "sha512-aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ=="
         }
       }
     },
     "core-js-pure": {
       "version": "3.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/core-js-pure/-/core-js-pure-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
       "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "requires": {
         "import-fresh": "^2.0.0",
@@ -3491,7 +3491,7 @@
     },
     "craco-less": {
       "version": "1.9.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/craco-less/-/craco-less-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/craco-less/-/craco-less-1.9.0.tgz",
       "integrity": "sha512-lwdjiYVLMemr40ioorYOw1W4u/9cmvZgtlPpEfhAOcXxr93sk+LxpkZMy8uxRAD1FAibKu7ZobX4selXBwqI6A==",
       "requires": {
         "less": "^3.8.1",
@@ -3501,7 +3501,7 @@
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -3510,7 +3510,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -3522,7 +3522,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -3535,7 +3535,7 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
         "nice-try": "^1.0.4",
@@ -3547,7 +3547,7 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -3565,7 +3565,7 @@
     },
     "css-blank-pseudo": {
       "version": "0.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
       "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
       "requires": {
         "postcss": "^7.0.5"
@@ -3573,12 +3573,12 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-declaration-sorter": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "requires": {
         "postcss": "^7.0.1",
@@ -3587,7 +3587,7 @@
     },
     "css-has-pseudo": {
       "version": "0.10.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
       "integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
       "requires": {
         "postcss": "^7.0.6",
@@ -3596,12 +3596,12 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
@@ -3613,7 +3613,7 @@
     },
     "css-loader": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-loader/-/css-loader-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
       "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
       "requires": {
         "camelcase": "^5.2.0",
@@ -3631,7 +3631,7 @@
     },
     "css-prefers-color-scheme": {
       "version": "3.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
       "integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
       "requires": {
         "postcss": "^7.0.5"
@@ -3639,7 +3639,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -3650,12 +3650,12 @@
     },
     "css-select-base-adapter": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-tree": {
       "version": "1.0.0-alpha.28",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
       "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
       "requires": {
         "mdn-data": "~1.1.0",
@@ -3664,39 +3664,39 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "css-unit-converter": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
     },
     "css-url-regex": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-url-regex/-/css-url-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
       "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
     },
     "css-what": {
       "version": "2.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/css-what/-/css-what-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "cssdb": {
       "version": "4.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssdb/-/cssdb-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
       "integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ=="
     },
     "cssesc": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
       "version": "4.1.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssnano/-/cssnano-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
       "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
       "requires": {
         "cosmiconfig": "^5.0.0",
@@ -3707,7 +3707,7 @@
     },
     "cssnano-preset-default": {
       "version": "4.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
       "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
       "requires": {
         "css-declaration-sorter": "^4.0.1",
@@ -3744,17 +3744,17 @@
     },
     "cssnano-util-get-arguments": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
       "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8="
     },
     "cssnano-util-get-match": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
       "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0="
     },
     "cssnano-util-raw-cache": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "requires": {
         "postcss": "^7.0.0"
@@ -3762,12 +3762,12 @@
     },
     "cssnano-util-same-parent": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
       "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q=="
     },
     "csso": {
       "version": "3.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/csso/-/csso-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
       "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
       "requires": {
         "css-tree": "1.0.0-alpha.29"
@@ -3775,7 +3775,7 @@
       "dependencies": {
         "css-tree": {
           "version": "1.0.0-alpha.29",
-          "resolved": "https://repo.adeo.no/repository/npm-public/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
           "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
           "requires": {
             "mdn-data": "~1.1.0",
@@ -3784,19 +3784,19 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "cssom": {
       "version": "0.3.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssom/-/cssom-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
       "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
     },
     "cssstyle": {
       "version": "1.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cssstyle/-/cssstyle-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
       "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
       "requires": {
         "cssom": "0.3.x"
@@ -3804,27 +3804,27 @@
     },
     "csstype": {
       "version": "2.6.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/csstype/-/csstype-2.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
       "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
     },
     "cuid": {
       "version": "2.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cuid/-/cuid-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.6.tgz",
       "integrity": "sha512-ZFp7PS6cSYMJNch9fc3tyHdE4T8TDo3Y5qAxb0KSA9mpiYDo7z9ql1CznFuuzxea9STVIDy0tJWm2lYiX2ZU1Q=="
     },
     "cyclist": {
       "version": "0.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/cyclist/-/cyclist-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "damerau-levenshtein": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
       "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA=="
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3832,7 +3832,7 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/data-urls/-/data-urls-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "requires": {
         "abab": "^2.0.0",
@@ -3842,7 +3842,7 @@
       "dependencies": {
         "whatwg-url": {
           "version": "7.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
           "requires": {
             "lodash.sortby": "^4.7.0",
@@ -3854,12 +3854,12 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
@@ -3867,32 +3867,32 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-diff": {
       "version": "0.3.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/deep-diff/-/deep-diff-0.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/deep-equal/-/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-gateway": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/default-gateway/-/default-gateway-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
       "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
       "requires": {
         "execa": "^1.0.0",
@@ -3901,7 +3901,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
@@ -3909,7 +3909,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -3918,7 +3918,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -3926,7 +3926,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -3934,7 +3934,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -3946,7 +3946,7 @@
     },
     "del": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/del/-/del-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
         "globby": "^6.1.0",
@@ -3959,7 +3959,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -3971,7 +3971,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://repo.adeo.no/repository/npm-public/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
@@ -3980,17 +3980,17 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
         "inherits": "^2.0.1",
@@ -3999,22 +3999,22 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/detect-newline/-/detect-newline-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
       "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
       "requires": {
         "address": "^1.0.1",
@@ -4023,12 +4023,12 @@
     },
     "diff-sequences": {
       "version": "24.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/diff-sequences/-/diff-sequences-24.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
       "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -4038,7 +4038,7 @@
     },
     "dir-glob": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dir-glob/-/dir-glob-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
         "arrify": "^1.0.1",
@@ -4047,17 +4047,17 @@
     },
     "discontinuous-range": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dns-equal/-/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
       "version": "1.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dns-packet/-/dns-packet-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
         "ip": "^1.1.0",
@@ -4066,7 +4066,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dns-txt/-/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
         "buffer-indexof": "^1.0.0"
@@ -4074,7 +4074,7 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "requires": {
         "esutils": "^2.0.2"
@@ -4082,7 +4082,7 @@
     },
     "dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dom-converter/-/dom-converter-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
@@ -4090,12 +4090,12 @@
     },
     "dom-scroll-into-view": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz",
       "integrity": "sha1-Mqu5Lw2P7KYhUWKu9D5LRJq42Zw="
     },
     "dom-serializer": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "requires": {
         "domelementtype": "^1.3.0",
@@ -4104,17 +4104,17 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/domain-browser/-/domain-browser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/domelementtype/-/domelementtype-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/domexception/-/domexception-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "requires": {
         "webidl-conversions": "^4.0.2"
@@ -4122,7 +4122,7 @@
     },
     "domhandler": {
       "version": "2.4.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/domhandler/-/domhandler-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
         "domelementtype": "1"
@@ -4130,7 +4130,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
         "dom-serializer": "0",
@@ -4139,7 +4139,7 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dot-prop/-/dot-prop-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
         "is-obj": "^1.0.0"
@@ -4147,22 +4147,22 @@
     },
     "dotenv": {
       "version": "6.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dotenv/-/dotenv-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
     "dotenv-expand": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
       "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU="
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/duplexify/-/duplexify-3.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -4173,7 +4173,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -4182,17 +4182,17 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.176",
-      "resolved": "https://repo.adeo.no/repository/npm-public/electron-to-chromium/-/electron-to-chromium-1.3.176.tgz",
-      "integrity": "sha512-hsQ/BH6x2iCvJ7WOIbNTAlsT39vsVGIVoJJ9i6ZkGXUE2LdzWsNv0xJI2uZ5/Hkqv1oTTLxAYjbtGKVJzqYbjA=="
+      "version": "1.3.179",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.179.tgz",
+      "integrity": "sha512-hRjlOdKImgIRicKYRY6hHbUMrX2NJYBrIusTepwPt/apcabuzrzhXpkkWu7elWdTZEQwKV6BfX8EvWIBWLCNQw=="
     },
     "elliptic": {
       "version": "6.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/elliptic/-/elliptic-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
       "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
       "requires": {
         "bn.js": "^4.4.0",
@@ -4206,22 +4206,22 @@
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
@@ -4229,7 +4229,7 @@
     },
     "enhanced-resolve": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
       "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -4239,12 +4239,12 @@
     },
     "entities": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/entities/-/entities-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "enzyme": {
       "version": "3.10.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/enzyme/-/enzyme-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
       "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -4272,7 +4272,7 @@
     },
     "enzyme-adapter-react-16": {
       "version": "1.14.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
       "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
       "requires": {
         "enzyme-adapter-utils": "^1.12.0",
@@ -4287,7 +4287,7 @@
     },
     "enzyme-adapter-utils": {
       "version": "1.12.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
       "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
       "requires": {
         "airbnb-prop-types": "^2.13.2",
@@ -4300,7 +4300,7 @@
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/errno/-/errno-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "~1.0.1"
@@ -4308,7 +4308,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -4316,7 +4316,7 @@
     },
     "es-abstract": {
       "version": "1.13.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/es-abstract/-/es-abstract-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -4329,7 +4329,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "requires": {
         "is-callable": "^1.1.4",
@@ -4339,17 +4339,17 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/escodegen/-/escodegen-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
       "requires": {
         "esprima": "^3.1.3",
@@ -4361,14 +4361,14 @@
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/esprima/-/esprima-3.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         }
       }
     },
     "eslint": {
       "version": "5.16.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint/-/eslint-5.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
       "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -4411,16 +4411,16 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "import-fresh": {
-          "version": "3.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/import-fresh/-/import-fresh-3.0.0.tgz",
-          "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+          "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
@@ -4428,19 +4428,19 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
       }
     },
     "eslint-config-react-app": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-config-react-app/-/eslint-config-react-app-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-4.0.1.tgz",
       "integrity": "sha512-ZsaoXUIGsK8FCi/x4lT2bZR5mMkL/Kgj+Lnw690rbvvUr/uiwgFiD8FcfAhkCycm7Xte6O5lYz4EqMx2vX7jgw==",
       "requires": {
         "confusing-browser-globals": "^1.0.7"
@@ -4448,7 +4448,7 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "requires": {
         "debug": "^2.6.9",
@@ -4457,7 +4457,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -4467,7 +4467,7 @@
     },
     "eslint-loader": {
       "version": "2.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-loader/-/eslint-loader-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.2.tgz",
       "integrity": "sha512-rA9XiXEOilLYPOIInvVH5S/hYfyTPyxag6DZhoQOduM+3TkghAEQ3VcFO8VnX4J4qg/UIBzp72aOf/xvYmpmsg==",
       "requires": {
         "loader-fs-cache": "^1.0.0",
@@ -4479,7 +4479,7 @@
     },
     "eslint-module-utils": {
       "version": "2.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
       "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "requires": {
         "debug": "^2.6.8",
@@ -4488,7 +4488,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
@@ -4496,7 +4496,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
@@ -4505,7 +4505,7 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-limit/-/p-limit-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
             "p-try": "^1.0.0"
@@ -4513,7 +4513,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
@@ -4521,12 +4521,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "pkg-dir": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "requires": {
             "find-up": "^2.1.0"
@@ -4536,7 +4536,7 @@
     },
     "eslint-plugin-flowtype": {
       "version": "2.50.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
       "integrity": "sha512-9kRxF9hfM/O6WGZcZPszOVPd2W0TLHBtceulLTsGfwMPtiCCLnCW0ssRiOOiXyqrCA20pm1iXdXm7gQeN306zQ==",
       "requires": {
         "lodash": "^4.17.10"
@@ -4544,7 +4544,7 @@
     },
     "eslint-plugin-import": {
       "version": "2.16.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
       "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
       "requires": {
         "contains-path": "^0.1.0",
@@ -4561,7 +4561,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
             "esutils": "^2.0.2",
@@ -4570,7 +4570,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
@@ -4578,7 +4578,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -4589,7 +4589,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
@@ -4598,7 +4598,7 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-limit/-/p-limit-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
             "p-try": "^1.0.0"
@@ -4606,7 +4606,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
@@ -4614,12 +4614,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/parse-json/-/parse-json-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
             "error-ex": "^1.2.0"
@@ -4627,7 +4627,7 @@
         },
         "path-type": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/path-type/-/path-type-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
             "pify": "^2.0.0"
@@ -4635,12 +4635,12 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/read-pkg/-/read-pkg-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
             "load-json-file": "^2.0.0",
@@ -4650,7 +4650,7 @@
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
             "find-up": "^2.0.0",
@@ -4659,7 +4659,7 @@
         },
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -4669,7 +4669,7 @@
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
       "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
       "requires": {
         "aria-query": "^3.0.0",
@@ -4684,7 +4684,7 @@
     },
     "eslint-plugin-react": {
       "version": "7.12.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
       "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
       "requires": {
         "array-includes": "^3.0.3",
@@ -4698,7 +4698,7 @@
       "dependencies": {
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/doctrine/-/doctrine-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "requires": {
             "esutils": "^2.0.2"
@@ -4706,7 +4706,7 @@
         },
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -4716,12 +4716,12 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "1.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
       "integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA=="
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "requires": {
         "esrecurse": "^4.1.0",
@@ -4730,17 +4730,17 @@
     },
     "eslint-utils": {
       "version": "1.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
       "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q=="
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/espree/-/espree-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
       "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "requires": {
         "acorn": "^6.0.7",
@@ -4750,12 +4750,12 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/esquery/-/esquery-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "requires": {
         "estraverse": "^4.0.0"
@@ -4763,7 +4763,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/esrecurse/-/esrecurse-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
         "estraverse": "^4.1.0"
@@ -4771,32 +4771,32 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
       "version": "3.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/events/-/events-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
     },
     "eventsource": {
       "version": "1.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eventsource/-/eventsource-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
       "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "requires": {
         "original": "^1.0.0"
@@ -4804,7 +4804,7 @@
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "^1.3.4",
@@ -4813,12 +4813,12 @@
     },
     "exec-sh": {
       "version": "0.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/exec-sh/-/exec-sh-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
       "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg=="
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "requires": {
         "cross-spawn": "^6.0.0",
@@ -4832,17 +4832,17 @@
     },
     "exenv": {
       "version": "1.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/exenv/-/exenv-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
       "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
@@ -4856,7 +4856,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -4864,7 +4864,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -4874,7 +4874,7 @@
     },
     "expect": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/expect/-/expect-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
       "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -4887,7 +4887,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/express/-/express-4.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
         "accepts": "~1.3.7",
@@ -4924,29 +4924,29 @@
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -4955,7 +4955,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -4965,7 +4965,7 @@
     },
     "external-editor": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/external-editor/-/external-editor-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "requires": {
         "chardet": "^0.7.0",
@@ -4975,7 +4975,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
         "array-unique": "^0.3.2",
@@ -4990,7 +4990,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -4998,7 +4998,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -5006,7 +5006,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -5014,7 +5014,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -5022,7 +5022,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -5034,17 +5034,17 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
       "version": "2.2.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fast-glob/-/fast-glob-2.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
       "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -5057,17 +5057,17 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "faye-websocket": {
       "version": "0.11.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
       "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
       "requires": {
         "websocket-driver": ">=0.5.1"
@@ -5075,7 +5075,7 @@
     },
     "fb-watchman": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
         "bser": "^2.0.0"
@@ -5083,12 +5083,12 @@
     },
     "figgy-pudding": {
       "version": "3.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
       "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/figures/-/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -5096,7 +5096,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "requires": {
         "flat-cache": "^2.0.1"
@@ -5104,7 +5104,7 @@
     },
     "file-loader": {
       "version": "3.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/file-loader/-/file-loader-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
       "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
       "requires": {
         "loader-utils": "^1.0.2",
@@ -5113,12 +5113,12 @@
     },
     "filesize": {
       "version": "3.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/filesize/-/filesize-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
       "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5129,7 +5129,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -5139,7 +5139,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
@@ -5153,7 +5153,7 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "requires": {
         "commondir": "^1.0.1",
@@ -5163,7 +5163,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
         "locate-path": "^3.0.0"
@@ -5171,7 +5171,7 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/flat-cache/-/flat-cache-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "requires": {
         "flatted": "^2.0.0",
@@ -5181,17 +5181,17 @@
     },
     "flatted": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/flatted/-/flatted-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
     },
     "flatten": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/flatten/-/flatten-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "requires": {
         "inherits": "^2.0.3",
@@ -5200,7 +5200,7 @@
     },
     "follow-redirects": {
       "version": "1.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
         "debug": "^3.2.6"
@@ -5208,7 +5208,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
@@ -5216,19 +5216,19 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
         "for-in": "^1.0.1"
@@ -5236,12 +5236,12 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.1.1.tgz",
       "integrity": "sha512-gqWAEMLlae/oeVnN6RWCAhesOJMswAN1MaKNqhhjXHV5O0/rTUjWI4UbgQHdlrVbCnb+xLotXmJbBlC66QmpFw==",
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -5256,7 +5256,7 @@
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
@@ -5266,12 +5266,12 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -5279,12 +5279,12 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
         "inherits": "^2.0.1",
@@ -5293,7 +5293,7 @@
     },
     "fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fs-extra/-/fs-extra-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5303,7 +5303,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5314,12 +5314,12 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
-      "resolved": "https://repo.adeo.no/repository/npm-public/fsevents/-/fsevents-1.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "optional": true,
       "requires": {
@@ -5800,12 +5800,12 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "requires": {
         "define-properties": "^1.1.2",
@@ -5815,22 +5815,22 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "get-caller-file": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
       "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
@@ -5838,12 +5838,12 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -5851,7 +5851,7 @@
     },
     "glob": {
       "version": "7.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/glob/-/glob-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -5864,7 +5864,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
         "is-glob": "^3.1.0",
@@ -5873,7 +5873,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -5883,12 +5883,12 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-modules": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/global-modules/-/global-modules-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "requires": {
         "global-prefix": "^3.0.0"
@@ -5896,7 +5896,7 @@
     },
     "global-prefix": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/global-prefix/-/global-prefix-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
       "requires": {
         "ini": "^1.3.5",
@@ -5906,12 +5906,12 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/globals/-/globals-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "8.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/globby/-/globby-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
       "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "requires": {
         "array-union": "^1.0.1",
@@ -5925,34 +5925,34 @@
       "dependencies": {
         "ignore": {
           "version": "3.3.10",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ignore/-/ignore-3.3.10.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
           "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
         },
         "slash": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/slash/-/slash-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         }
       }
     },
     "graceful-fs": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "gud": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/gud/-/gud-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gzip-size": {
       "version": "5.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/gzip-size/-/gzip-size-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
       "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
       "requires": {
         "duplexer": "^0.1.1",
@@ -5961,12 +5961,12 @@
     },
     "handle-thing": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/handle-thing/-/handle-thing-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
       "version": "4.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/handlebars/-/handlebars-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
       "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "requires": {
         "neo-async": "^2.6.0",
@@ -5977,12 +5977,12 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
         "ajv": "^6.5.5",
@@ -5991,12 +5991,12 @@
     },
     "harmony-reflect": {
       "version": "1.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
       "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/has/-/has-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
@@ -6004,7 +6004,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -6012,24 +6012,24 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -6039,7 +6039,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
@@ -6048,7 +6048,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6058,7 +6058,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hash-base/-/hash-base-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
         "inherits": "^2.0.1",
@@ -6067,7 +6067,7 @@
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hash.js/-/hash.js-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
@@ -6076,7 +6076,7 @@
     },
     "hast-util-from-parse5": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hast-util-from-parse5/-/hast-util-from-parse5-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.1.tgz",
       "integrity": "sha512-UfPzdl6fbxGAxqGYNThRUhRlDYY7sXu6XU9nQeX4fFZtV+IHbyEJtd+DUuwOqNV4z3K05E/1rIkoVr/JHmeWWA==",
       "requires": {
         "ccount": "^1.0.3",
@@ -6088,12 +6088,12 @@
     },
     "hast-util-parse-selector": {
       "version": "2.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz",
       "integrity": "sha512-jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw=="
     },
     "hastscript": {
       "version": "5.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hastscript/-/hastscript-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.0.tgz",
       "integrity": "sha512-7mOQX5VfVs/gmrOGlN8/EDfp1GqV6P3gTNVt+KnX4gbYhpASTM8bklFdFQCbFRAadURXAmw0R1QQdBdqp7jswQ==",
       "requires": {
         "comma-separated-tokens": "^1.0.0",
@@ -6104,17 +6104,17 @@
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/he/-/he-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hex-color-regex": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "history": {
       "version": "4.9.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/history/-/history-4.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
       "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
@@ -6127,7 +6127,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
         "hash.js": "^1.0.3",
@@ -6137,7 +6137,7 @@
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
       "requires": {
         "react-is": "^16.7.0"
@@ -6145,12 +6145,12 @@
     },
     "hosted-git-info": {
       "version": "2.7.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
         "inherits": "^2.0.1",
@@ -6161,22 +6161,22 @@
     },
     "hsl-regex": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
       "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4="
     },
     "hsla-regex": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
     },
     "html-comment-regex": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
     "html-element-map": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/html-element-map/-/html-element-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
       "integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
       "requires": {
         "array-filter": "^1.0.0"
@@ -6184,7 +6184,7 @@
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "requires": {
         "whatwg-encoding": "^1.0.1"
@@ -6192,12 +6192,12 @@
     },
     "html-entities": {
       "version": "1.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/html-entities/-/html-entities-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-minifier": {
       "version": "3.5.21",
-      "resolved": "https://repo.adeo.no/repository/npm-public/html-minifier/-/html-minifier-3.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
       "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "requires": {
         "camel-case": "3.0.x",
@@ -6211,14 +6211,14 @@
       "dependencies": {
         "commander": {
           "version": "2.17.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/commander/-/commander-2.17.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
         }
       }
     },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
       "integrity": "sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==",
       "requires": {
         "html-minifier": "^3.5.20",
@@ -6231,7 +6231,7 @@
     },
     "htmlparser2": {
       "version": "3.10.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "requires": {
         "domelementtype": "^1.3.1",
@@ -6244,7 +6244,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/readable-stream/-/readable-stream-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
@@ -6256,12 +6256,12 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "~1.1.2",
@@ -6273,19 +6273,19 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "http-parser-js": {
       "version": "0.4.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
       "version": "1.17.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/http-proxy/-/http-proxy-1.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
         "eventemitter3": "^3.0.0",
@@ -6295,7 +6295,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
       "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
       "requires": {
         "http-proxy": "^1.17.0",
@@ -6306,7 +6306,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -6316,7 +6316,7 @@
     },
     "httpplease": {
       "version": "0.16.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/httpplease/-/httpplease-0.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/httpplease/-/httpplease-0.16.4.tgz",
       "integrity": "sha1-04Lr4jDvUHkIC06f/r8xap51wNo=",
       "requires": {
         "urllite": "~0.5.0",
@@ -6326,19 +6326,19 @@
       "dependencies": {
         "xtend": {
           "version": "3.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/xtend/-/xtend-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
         }
       }
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://repo.adeo.no/repository/npm-public/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -6346,12 +6346,12 @@
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
     "icss-utils": {
       "version": "4.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/icss-utils/-/icss-utils-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "requires": {
         "postcss": "^7.0.14"
@@ -6359,7 +6359,7 @@
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "requires": {
         "harmony-reflect": "^1.4.6"
@@ -6367,38 +6367,38 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ieee754/-/ieee754-1.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "ignore": {
       "version": "4.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ignore/-/ignore-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "image-size": {
       "version": "0.5.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/image-size/-/image-size-0.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "optional": true
     },
     "immer": {
       "version": "1.10.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/immer/-/immer-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
     },
     "immutable": {
       "version": "3.8.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/immutable/-/immutable-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/import-cwd/-/import-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "requires": {
         "import-from": "^2.1.0"
@@ -6406,7 +6406,7 @@
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/import-fresh/-/import-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "requires": {
         "caller-path": "^2.0.0",
@@ -6415,7 +6415,7 @@
     },
     "import-from": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/import-from/-/import-from-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
         "resolve-from": "^3.0.0"
@@ -6423,7 +6423,7 @@
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/import-local/-/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "requires": {
         "pkg-dir": "^3.0.0",
@@ -6432,17 +6432,17 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -6451,17 +6451,17 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ini/-/ini-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "6.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/inquirer/-/inquirer-6.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
       "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -6481,12 +6481,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -6496,7 +6496,7 @@
     },
     "internal-ip": {
       "version": "4.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/internal-ip/-/internal-ip-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
       "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
       "requires": {
         "default-gateway": "^4.2.0",
@@ -6505,17 +6505,17 @@
     },
     "intl": {
       "version": "1.2.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/intl/-/intl-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
       "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
     },
     "intl-format-cache": {
       "version": "2.2.9",
-      "resolved": "https://repo.adeo.no/repository/npm-public/intl-format-cache/-/intl-format-cache-2.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.2.9.tgz",
       "integrity": "sha512-Zv/u8wRpekckv0cLkwpVdABYST4hZNTDaX7reFetrYTJwxExR2VyTqQm+l0WmL0Qo8Mjb9Tf33qnfj0T7pjxdQ=="
     },
     "intl-messageformat": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
       "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
       "requires": {
         "intl-messageformat-parser": "1.4.0"
@@ -6523,12 +6523,12 @@
     },
     "intl-messageformat-parser": {
       "version": "1.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
       "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
     },
     "intl-relativeformat": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/intl-relativeformat/-/intl-relativeformat-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.2.0.tgz",
       "integrity": "sha512-4bV/7kSKaPEmu6ArxXf9xjv1ny74Zkwuey8Pm01NH4zggPP7JHwg2STk8Y3JdspCKRDriwIyLRfEXnj2ZLr4Bw==",
       "requires": {
         "intl-messageformat": "^2.0.0"
@@ -6536,7 +6536,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
@@ -6544,32 +6544,32 @@
     },
     "invert-kv": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/invert-kv/-/invert-kv-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
       "version": "1.9.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -6577,7 +6577,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6587,12 +6587,12 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -6600,22 +6600,22 @@
     },
     "is-boolean-object": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
       "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-callable/-/is-callable-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "requires": {
         "ci-info": "^2.0.0"
@@ -6623,7 +6623,7 @@
     },
     "is-color-stop": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-color-stop/-/is-color-stop-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "requires": {
         "css-color-names": "^0.0.4",
@@ -6636,7 +6636,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -6644,7 +6644,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6654,12 +6654,12 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -6669,39 +6669,39 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-glob/-/is-glob-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
         "is-extglob": "^2.1.1"
@@ -6709,7 +6709,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -6717,7 +6717,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6727,22 +6727,22 @@
     },
     "is-number-object": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-number-object/-/is-number-object-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
       "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
         "is-path-inside": "^1.0.0"
@@ -6750,7 +6750,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "^1.0.1"
@@ -6758,12 +6758,12 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
@@ -6771,12 +6771,12 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
         "has": "^1.0.1"
@@ -6784,37 +6784,37 @@
     },
     "is-regexp": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-regexp/-/is-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "is-root": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-root/-/is-root-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
       "integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg=="
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-string/-/is-string-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
       "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
     },
     "is-subset": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-subset/-/is-subset-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
     },
     "is-svg": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-svg/-/is-svg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "requires": {
         "html-comment-regex": "^1.1.0"
@@ -6822,7 +6822,7 @@
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-symbol/-/is-symbol-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "requires": {
         "has-symbols": "^1.0.0"
@@ -6830,47 +6830,47 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "requires": {
         "@babel/generator": "^7.4.0",
@@ -6883,15 +6883,15 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/semver/-/semver-6.1.2.tgz",
-          "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ=="
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.3.tgz",
+          "integrity": "sha512-aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ=="
         }
       }
     },
     "istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "requires": {
         "istanbul-lib-coverage": "^2.0.5",
@@ -6901,7 +6901,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -6911,7 +6911,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "requires": {
         "debug": "^4.1.1",
@@ -6923,7 +6923,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -6931,14 +6931,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "istanbul-reports": {
       "version": "2.2.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
       "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "requires": {
         "handlebars": "^4.1.2"
@@ -6946,7 +6946,7 @@
     },
     "jest": {
       "version": "24.7.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest/-/jest-24.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.7.1.tgz",
       "integrity": "sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==",
       "requires": {
         "import-local": "^2.0.0",
@@ -6955,7 +6955,7 @@
       "dependencies": {
         "jest-cli": {
           "version": "24.8.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jest-cli/-/jest-cli-24.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
           "integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
           "requires": {
             "@jest/core": "^24.8.0",
@@ -6977,7 +6977,7 @@
     },
     "jest-changed-files": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
       "integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -6987,7 +6987,7 @@
     },
     "jest-config": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-config/-/jest-config-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
       "integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
       "requires": {
         "@babel/core": "^7.1.0",
@@ -7011,7 +7011,7 @@
       "dependencies": {
         "jest-resolve": {
           "version": "24.8.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve/-/jest-resolve-24.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
           "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
           "requires": {
             "@jest/types": "^24.8.0",
@@ -7025,7 +7025,7 @@
     },
     "jest-diff": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-diff/-/jest-diff-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
       "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
       "requires": {
         "chalk": "^2.0.1",
@@ -7036,7 +7036,7 @@
     },
     "jest-docblock": {
       "version": "24.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-docblock/-/jest-docblock-24.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
       "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
       "requires": {
         "detect-newline": "^2.1.0"
@@ -7044,7 +7044,7 @@
     },
     "jest-each": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-each/-/jest-each-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
       "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -7056,7 +7056,7 @@
     },
     "jest-environment-jsdom": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
       "integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
       "requires": {
         "@jest/environment": "^24.8.0",
@@ -7069,7 +7069,7 @@
     },
     "jest-environment-jsdom-fourteen": {
       "version": "0.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-0.1.0.tgz",
       "integrity": "sha512-4vtoRMg7jAstitRzL4nbw83VmGH8Rs13wrND3Ud2o1fczDhMUF32iIrNKwYGgeOPUdfvZU4oy8Bbv+ni1fgVCA==",
       "requires": {
         "jest-mock": "^24.5.0",
@@ -7079,7 +7079,7 @@
       "dependencies": {
         "jsdom": {
           "version": "14.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jsdom/-/jsdom-14.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
           "integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
           "requires": {
             "abab": "^2.0.0",
@@ -7112,12 +7112,12 @@
         },
         "parse5": {
           "version": "5.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/parse5/-/parse5-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
           "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
         },
         "tough-cookie": {
           "version": "2.5.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "requires": {
             "psl": "^1.1.28",
@@ -7126,7 +7126,7 @@
         },
         "whatwg-url": {
           "version": "7.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
           "requires": {
             "lodash.sortby": "^4.7.0",
@@ -7136,7 +7136,7 @@
         },
         "ws": {
           "version": "6.2.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ws/-/ws-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "requires": {
             "async-limiter": "~1.0.0"
@@ -7146,7 +7146,7 @@
     },
     "jest-environment-node": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
       "integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
       "requires": {
         "@jest/environment": "^24.8.0",
@@ -7158,12 +7158,12 @@
     },
     "jest-get-type": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-get-type/-/jest-get-type-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
       "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ=="
     },
     "jest-haste-map": {
       "version": "24.8.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
       "integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -7182,7 +7182,7 @@
     },
     "jest-jasmine2": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
       "integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
       "requires": {
         "@babel/traverse": "^7.1.0",
@@ -7205,7 +7205,7 @@
     },
     "jest-leak-detector": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
       "integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
       "requires": {
         "pretty-format": "^24.8.0"
@@ -7213,7 +7213,7 @@
     },
     "jest-matcher-utils": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
       "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
       "requires": {
         "chalk": "^2.0.1",
@@ -7224,7 +7224,7 @@
     },
     "jest-message-util": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-message-util/-/jest-message-util-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
       "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -7239,7 +7239,7 @@
     },
     "jest-mock": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-mock/-/jest-mock-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
       "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
       "requires": {
         "@jest/types": "^24.8.0"
@@ -7247,17 +7247,17 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ=="
     },
     "jest-regex-util": {
       "version": "24.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
       "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg=="
     },
     "jest-resolve": {
       "version": "24.7.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve/-/jest-resolve-24.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.7.1.tgz",
       "integrity": "sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==",
       "requires": {
         "@jest/types": "^24.7.0",
@@ -7269,7 +7269,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
       "integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -7279,7 +7279,7 @@
     },
     "jest-runner": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-runner/-/jest-runner-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
       "integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
       "requires": {
         "@jest/console": "^24.7.1",
@@ -7305,7 +7305,7 @@
       "dependencies": {
         "jest-resolve": {
           "version": "24.8.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve/-/jest-resolve-24.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
           "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
           "requires": {
             "@jest/types": "^24.8.0",
@@ -7319,7 +7319,7 @@
     },
     "jest-runtime": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-runtime/-/jest-runtime-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
       "integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
       "requires": {
         "@jest/console": "^24.7.1",
@@ -7349,7 +7349,7 @@
       "dependencies": {
         "jest-resolve": {
           "version": "24.8.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve/-/jest-resolve-24.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
           "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
           "requires": {
             "@jest/types": "^24.8.0",
@@ -7363,12 +7363,12 @@
     },
     "jest-serializer": {
       "version": "24.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-serializer/-/jest-serializer-24.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
       "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q=="
     },
     "jest-snapshot": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
       "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
       "requires": {
         "@babel/types": "^7.0.0",
@@ -7387,7 +7387,7 @@
       "dependencies": {
         "jest-resolve": {
           "version": "24.8.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jest-resolve/-/jest-resolve-24.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
           "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
           "requires": {
             "@jest/types": "^24.8.0",
@@ -7401,7 +7401,7 @@
     },
     "jest-util": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-util/-/jest-util-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
       "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
       "requires": {
         "@jest/console": "^24.7.1",
@@ -7420,14 +7420,14 @@
       "dependencies": {
         "callsites": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/callsites/-/callsites-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
           "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         }
       }
     },
     "jest-validate": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-validate/-/jest-validate-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
       "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -7440,7 +7440,7 @@
     },
     "jest-watch-typeahead": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-watch-typeahead/-/jest-watch-typeahead-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.3.0.tgz",
       "integrity": "sha512-+uOtlppt9ysST6k6ZTqsPI0WNz2HLa8bowiZylZoQCQaAVn7XsVmHhZREkz73FhKelrFrpne4hQQjdq42nFEmA==",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -7453,12 +7453,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -7468,7 +7468,7 @@
     },
     "jest-watcher": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-watcher/-/jest-watcher-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
       "integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
       "requires": {
         "@jest/test-result": "^24.8.0",
@@ -7482,7 +7482,7 @@
     },
     "jest-worker": {
       "version": "24.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jest-worker/-/jest-worker-24.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
       "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
       "requires": {
         "merge-stream": "^1.0.1",
@@ -7491,7 +7491,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -7501,17 +7501,17 @@
     },
     "js-levenshtein": {
       "version": "1.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/js-yaml/-/js-yaml-3.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
@@ -7520,12 +7520,12 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "11.12.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsdom/-/jsdom-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "requires": {
         "abab": "^2.0.0",
@@ -7558,39 +7558,39 @@
       "dependencies": {
         "acorn": {
           "version": "5.7.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/acorn/-/acorn-5.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
           "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
         }
       }
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
         "jsonify": "~0.0.0"
@@ -7598,22 +7598,22 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json3/-/json3-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
       "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "json5": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/json5/-/json5-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
         "minimist": "^1.2.0"
@@ -7621,14 +7621,14 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -7636,12 +7636,12 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -7651,9 +7651,9 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/jsx-ast-utils/-/jsx-ast-utils-2.2.0.tgz",
-      "integrity": "sha512-yAmhGSzR7TsD0OQpu1AGLz8Bx84cxMqtgoJrufomY6BlveEDlREhvu1rea21936xbe5tlUh7IPda82m5ae0H8Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
       "requires": {
         "array-includes": "^3.0.3",
         "object.assign": "^4.1.0"
@@ -7661,22 +7661,22 @@
     },
     "killable": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/killable/-/killable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
       "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
     },
     "kind-of": {
       "version": "6.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "kleur": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/kleur/-/kleur-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
       "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
       "requires": {
         "lodash": "^4.17.5",
@@ -7685,12 +7685,12 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lcid": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lcid/-/lcid-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "requires": {
         "invert-kv": "^2.0.0"
@@ -7698,12 +7698,12 @@
     },
     "left-pad": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/left-pad/-/left-pad-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
     "less": {
       "version": "3.9.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/less/-/less-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
       "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
       "requires": {
         "clone": "^2.1.2",
@@ -7719,7 +7719,7 @@
     },
     "less-loader": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/less-loader/-/less-loader-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-4.1.0.tgz",
       "integrity": "sha512-KNTsgCE9tMOM70+ddxp9yyt9iHqgmSs0yTZc5XH5Wo+g80RWRIYNqE58QJKm/yMud5wZEvz50ugRDuzVIkyahg==",
       "requires": {
         "clone": "^2.1.1",
@@ -7729,7 +7729,7 @@
     },
     "less-plugin-npm-import": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/less-plugin-npm-import/-/less-plugin-npm-import-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/less-plugin-npm-import/-/less-plugin-npm-import-2.1.0.tgz",
       "integrity": "sha1-gj5phskzGKmBccqFiEi2vq1Vvz4=",
       "requires": {
         "promise": "~7.0.1",
@@ -7738,7 +7738,7 @@
       "dependencies": {
         "promise": {
           "version": "7.0.4",
-          "resolved": "https://repo.adeo.no/repository/npm-public/promise/-/promise-7.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
           "integrity": "sha1-Nj6EpMNsg1a4kP7WLJHOhdAu1Tk=",
           "requires": {
             "asap": "~2.0.3"
@@ -7748,12 +7748,12 @@
     },
     "leven": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/leven/-/leven-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -7762,7 +7762,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -7773,7 +7773,7 @@
     },
     "loader-fs-cache": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
       "integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
       "requires": {
         "find-cache-dir": "^0.1.1",
@@ -7782,7 +7782,7 @@
       "dependencies": {
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "requires": {
             "commondir": "^1.0.1",
@@ -7792,7 +7792,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
             "path-exists": "^2.0.0",
@@ -7801,7 +7801,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -7809,7 +7809,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "requires": {
             "find-up": "^1.0.0"
@@ -7819,12 +7819,12 @@
     },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/loader-runner/-/loader-runner-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
       "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
     },
     "loader-utils": {
       "version": "1.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/loader-utils/-/loader-utils-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
       "requires": {
         "big.js": "^5.2.2",
@@ -7834,7 +7834,7 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
         "p-locate": "^3.0.0",
@@ -7843,59 +7843,59 @@
     },
     "lodash": {
       "version": "4.17.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash/-/lodash-4.17.11.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash-es": {
       "version": "4.17.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash-es/-/lodash-es-4.17.11.tgz",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
       "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.escape": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.tail": {
       "version": "4.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.tail/-/lodash.tail-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
     },
     "lodash.template": {
       "version": "4.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.template/-/lodash.template-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
         "lodash._reinterpolate": "~3.0.0",
@@ -7904,7 +7904,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
         "lodash._reinterpolate": "~3.0.0"
@@ -7912,27 +7912,27 @@
     },
     "lodash.throttle": {
       "version": "4.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.unescape": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "loglevel": {
       "version": "1.6.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/loglevel/-/loglevel-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA=="
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7940,12 +7940,12 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
         "yallist": "^3.0.2"
@@ -7953,7 +7953,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "requires": {
         "pify": "^4.0.1",
@@ -7962,14 +7962,14 @@
       "dependencies": {
         "pify": {
           "version": "4.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/pify/-/pify-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
     "makeerror": {
       "version": "1.0.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "requires": {
         "tmpl": "1.0.x"
@@ -7977,12 +7977,12 @@
     },
     "mamacro": {
       "version": "0.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mamacro/-/mamacro-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
       "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "requires": {
         "p-defer": "^1.0.0"
@@ -7990,12 +7990,12 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -8003,7 +8003,7 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/md5.js/-/md5.js-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
         "hash-base": "^3.0.0",
@@ -8013,17 +8013,17 @@
     },
     "mdn-data": {
       "version": "1.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mdn-data/-/mdn-data-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mem/-/mem-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "requires": {
         "map-age-cleaner": "^0.1.1",
@@ -8033,14 +8033,14 @@
       "dependencies": {
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         }
       }
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
         "errno": "^0.1.3",
@@ -8049,7 +8049,7 @@
     },
     "merge-deep": {
       "version": "3.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/merge-deep/-/merge-deep-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
       "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
       "requires": {
         "arr-union": "^3.1.0",
@@ -8059,7 +8059,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -8069,12 +8069,12 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/merge-stream/-/merge-stream-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
         "readable-stream": "^2.0.1"
@@ -8082,22 +8082,22 @@
     },
     "merge2": {
       "version": "1.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/merge2/-/merge2-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "microevent.ts": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/microevent.ts/-/microevent.ts-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g=="
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -8117,7 +8117,7 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
         "bn.js": "^4.0.0",
@@ -8126,17 +8126,17 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mime-db/-/mime-db-1.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mime-types/-/mime-types-2.1.24.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
         "mime-db": "1.40.0"
@@ -8144,12 +8144,12 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mini-create-react-context": {
       "version": "0.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
       "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
       "requires": {
         "@babel/runtime": "^7.4.0",
@@ -8159,7 +8159,7 @@
     },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
       "integrity": "sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==",
       "requires": {
         "loader-utils": "^1.1.0",
@@ -8169,17 +8169,17 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -8187,12 +8187,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mississippi/-/mississippi-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "requires": {
         "concat-stream": "^1.5.0",
@@ -8209,7 +8209,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
@@ -8218,7 +8218,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -8228,7 +8228,7 @@
     },
     "mixin-object": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mixin-object/-/mixin-object-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
         "for-in": "^0.1.3",
@@ -8237,14 +8237,14 @@
       "dependencies": {
         "for-in": {
           "version": "0.1.8",
-          "resolved": "https://repo.adeo.no/repository/npm-public/for-in/-/for-in-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
           "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -8252,12 +8252,12 @@
     },
     "moo": {
       "version": "0.4.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/moo/-/moo-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
       "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "requires": {
         "aproba": "^1.1.1",
@@ -8270,12 +8270,12 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
         "dns-packet": "^1.3.1",
@@ -8284,23 +8284,23 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nan/-/nan-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -8318,152 +8318,152 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "nav-frontend-alertstriper": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-alertstriper/-/nav-frontend-alertstriper-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-alertstriper/-/nav-frontend-alertstriper-3.0.3.tgz",
       "integrity": "sha512-/yK6vOisYVD6zyIGJgFb/CstAfldzLjgDExhecdhu/2mRKdB2GRR5sUeG0XlT46lVB23IGol/Gmiv9rM01ejwQ=="
     },
     "nav-frontend-alertstriper-style": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-alertstriper-style/-/nav-frontend-alertstriper-style-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-alertstriper-style/-/nav-frontend-alertstriper-style-2.0.2.tgz",
       "integrity": "sha512-SNe6oRP289ZRsdZhN4c247AWJ8oEyuhGabXWyK1RlpGn7ZYVscE2lLlNBAHYT5R5K2fw9wn+nOfBPflYc0rC2w=="
     },
     "nav-frontend-chevron": {
       "version": "1.0.9",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-chevron/-/nav-frontend-chevron-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-chevron/-/nav-frontend-chevron-1.0.9.tgz",
       "integrity": "sha512-G/Rjx7e5MYdsqAI8qGakJV+F92BEXIrm3Hx7+lXLoz4GoFCJJR0G2+Q+Uy7Iqu9FbdJOBGgapZXEIbiIEbKdmQ=="
     },
     "nav-frontend-chevron-style": {
       "version": "0.3.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-chevron-style/-/nav-frontend-chevron-style-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-chevron-style/-/nav-frontend-chevron-style-0.3.4.tgz",
       "integrity": "sha512-pAWxabxXujZhwgYUvkWyuuLEDbyYP52VmA0jeXicJT6vfxHewkycMIgP4TqPPrHtPyNx2SVEa+RPK+OiPMcRPw=="
     },
     "nav-frontend-core": {
       "version": "4.0.9",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-core/-/nav-frontend-core-4.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-core/-/nav-frontend-core-4.0.9.tgz",
       "integrity": "sha512-dCc2jFSA+LJXtfIP1n4eiEfCGIrirgEt88UMVwRCgT3wOz3kky387e6gFBHhUX8knEczV4ujOp428uip6sEuJw=="
     },
     "nav-frontend-ekspanderbartpanel": {
       "version": "1.0.28",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-ekspanderbartpanel/-/nav-frontend-ekspanderbartpanel-1.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-ekspanderbartpanel/-/nav-frontend-ekspanderbartpanel-1.0.28.tgz",
       "integrity": "sha512-x1eQL+iwl65LkehEda28dotqze+WWW7ZdPIWgd1C2FKxh5IPoo+k65r8he9BYkfF0ty6pnYBsZwS32JcrLUucg=="
     },
     "nav-frontend-ekspanderbartpanel-style": {
       "version": "0.3.20",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-ekspanderbartpanel-style/-/nav-frontend-ekspanderbartpanel-style-0.3.20.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-ekspanderbartpanel-style/-/nav-frontend-ekspanderbartpanel-style-0.3.20.tgz",
       "integrity": "sha512-FXGoMXt7VU9hySUxK0Rv5YwhZJV2qov6vKcKxQ0f9hqrdL1WmtE68ndGr7q8LVZaHa3ZS4ymMt7AI55rutA15w=="
     },
     "nav-frontend-grid": {
       "version": "1.0.21",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-grid/-/nav-frontend-grid-1.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-grid/-/nav-frontend-grid-1.0.21.tgz",
       "integrity": "sha512-R2IM/A5hsPg9AQ1XJCldHufgnzufMCUoc876uIPGsJN3ScKm27ZIJHTqBeQpOOrH4id2hJ0sSkeZ/T36asZDNg=="
     },
     "nav-frontend-grid-style": {
       "version": "0.2.18",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-grid-style/-/nav-frontend-grid-style-0.2.18.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-grid-style/-/nav-frontend-grid-style-0.2.18.tgz",
       "integrity": "sha512-+r5JsDxCbgjr+kXnjBmTgM4YvshmTgXqAEa2+UjzlI5KVEeyGksJ1ZmNVFKYISVpyhItWgq9oJ0+B6fScL/vpg=="
     },
     "nav-frontend-hjelpetekst": {
       "version": "1.0.39",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-hjelpetekst/-/nav-frontend-hjelpetekst-1.0.39.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-hjelpetekst/-/nav-frontend-hjelpetekst-1.0.39.tgz",
       "integrity": "sha512-YpNqmt/Klnw0H2baN420q/MNvVUW2JOpKJxZuWK8OnfOL8+dkimCIr37ie/jL0hpHkvHWZeW/ptQ5FzQ5VX6fA=="
     },
     "nav-frontend-hjelpetekst-style": {
       "version": "0.3.29",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-hjelpetekst-style/-/nav-frontend-hjelpetekst-style-0.3.29.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-hjelpetekst-style/-/nav-frontend-hjelpetekst-style-0.3.29.tgz",
       "integrity": "sha512-B43NYVNXmOC4VxmvYk1WWpOYVKgVuqKRBYWTn1IdDTeOAP0Vr+fsMjb1Cm5UltoNXvQk6tG4MNQPjMrxcQBCVw=="
     },
     "nav-frontend-ikoner-assets": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-ikoner-assets/-/nav-frontend-ikoner-assets-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-ikoner-assets/-/nav-frontend-ikoner-assets-1.0.1.tgz",
       "integrity": "sha512-+115YXOYtF5+tOc7zeDQz+X/ZYjdPJJ+coxzeBMDuGkg+Zf+yIzrZUv9Wc0B0gBoAQEDt0NbB1Eza6R2gFEamA=="
     },
     "nav-frontend-js-utils": {
       "version": "1.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.7.tgz",
       "integrity": "sha512-/XzbrFCfIou61E+fpeuyiKG5SVFd2EYUk96B9SfP8BZLwfRMjNdFieWpu0WP//5KbR9sMhpbqc2evzTnzXyrfQ=="
     },
     "nav-frontend-knapper": {
       "version": "1.0.30",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-knapper/-/nav-frontend-knapper-1.0.30.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-knapper/-/nav-frontend-knapper-1.0.30.tgz",
       "integrity": "sha512-d5ttmI/BjdX1FbhnAwWa1pZuV10xVtp1y5AZwMt0PXfxA/hPd0x9owcMXkGpnO4NXpUHwQqxWuS9t2XUwQ6seQ=="
     },
     "nav-frontend-knapper-style": {
       "version": "0.3.26",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-knapper-style/-/nav-frontend-knapper-style-0.3.26.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-knapper-style/-/nav-frontend-knapper-style-0.3.26.tgz",
       "integrity": "sha512-a0syl4T0LUI9Bq29Af9hYM/jazpSSoy2hp6SLMAS5H2Va+8j+/dpSFFqJ0Jc5hBclVOCMBNajMx6PxhK9LYDMw=="
     },
     "nav-frontend-lenker-style": {
       "version": "0.2.20",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-lenker-style/-/nav-frontend-lenker-style-0.2.20.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-lenker-style/-/nav-frontend-lenker-style-0.2.20.tgz",
       "integrity": "sha512-0RGEhYsH/xACgARAyuV/OeLXE62fXc4v5bzfkQ0bP/dAOZl483aZV7NHGxwm1eiY/wT1RqcBBCjg/Y7S+G3nCQ=="
     },
     "nav-frontend-lukknapp": {
       "version": "1.0.21",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-lukknapp/-/nav-frontend-lukknapp-1.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-lukknapp/-/nav-frontend-lukknapp-1.0.21.tgz",
       "integrity": "sha512-QLjZumXqWI0AhEsOxSaH0A+fUBv1xb2CnKAcpBkR37h86jxgT/tI1ksZplortn04VDrUBt6RoZEXf2I5XbapZA=="
     },
     "nav-frontend-lukknapp-style": {
       "version": "0.2.19",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-lukknapp-style/-/nav-frontend-lukknapp-style-0.2.19.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-lukknapp-style/-/nav-frontend-lukknapp-style-0.2.19.tgz",
       "integrity": "sha512-5en3QBgDOqkDOEzaofxor5AbnnAlWStm5ZXO+/sS0ReF94TiHOo9kHCnDjQl7o/PYisKMwv909HN5RswLrpdLA=="
     },
     "nav-frontend-modal": {
       "version": "1.0.28",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-modal/-/nav-frontend-modal-1.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-modal/-/nav-frontend-modal-1.0.28.tgz",
       "integrity": "sha512-1WuwApv8sd/DBtRvikBmshoK5uxyYbtEu3I3KxXP8IzqkKS46ckdoo5U3AOmcGnQvspgYvUarKycA3gPEjWEFg=="
     },
     "nav-frontend-modal-style": {
       "version": "0.3.29",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-modal-style/-/nav-frontend-modal-style-0.3.29.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-modal-style/-/nav-frontend-modal-style-0.3.29.tgz",
       "integrity": "sha512-1jPSizq1VOBr1b6/kA9Ki+Ke6hChbkfPKtlRS7a/YRuc0GtIDYiOMJhpqabCJh9drq9Fz+x0//7C9zxze/+EDA=="
     },
     "nav-frontend-paneler": {
       "version": "1.0.17",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-paneler/-/nav-frontend-paneler-1.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-paneler/-/nav-frontend-paneler-1.0.17.tgz",
       "integrity": "sha512-1ASPwIraZIbsZa+iIx9Dafztu//8DXf6MBvy02tcitEhfaRRK00/Jf26HdFAbwbdvRHqjXFDGi8KiumFaHZb1g=="
     },
     "nav-frontend-paneler-style": {
       "version": "0.3.15",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-paneler-style/-/nav-frontend-paneler-style-0.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-paneler-style/-/nav-frontend-paneler-style-0.3.15.tgz",
       "integrity": "sha512-NbslWxU2XHun7Xp0aR2G6rkrd69dNDTScQhOck6pKFA3rBAV/mdf/gbOAdIWQl+mq4M/V1ElYCZ7C/5F193Dtw=="
     },
     "nav-frontend-skjema": {
       "version": "1.0.67",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-skjema/-/nav-frontend-skjema-1.0.67.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-1.0.67.tgz",
       "integrity": "sha512-IHUBUBsbzfAF6TCdHNrBe6bdqMbUYEW/6QYmJ9Y0nhO/tMOASFq8ugBlAW8xuO1iEBUd3k3VJEtIOBN7uWwltg=="
     },
     "nav-frontend-skjema-style": {
       "version": "1.0.40",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-skjema-style/-/nav-frontend-skjema-style-1.0.40.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-skjema-style/-/nav-frontend-skjema-style-1.0.40.tgz",
       "integrity": "sha512-/r7rycF2ihrcSD8QPPdNNGxHI2gkFBibT5ipsxu4512GxNowNDfBriZ9H3FHIN3RRklEsLKTytVDaDjXHenolQ=="
     },
     "nav-frontend-spinner": {
       "version": "1.0.18",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-spinner/-/nav-frontend-spinner-1.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-spinner/-/nav-frontend-spinner-1.0.18.tgz",
       "integrity": "sha512-2ojDpOrnrNWGoCp51cVzdltxKWvq3M6LMIy+cfEpsxVJDx8KCOTHxt/mw8qadavQrAByvxnKVxRNFLjji10tZA=="
     },
     "nav-frontend-spinner-style": {
       "version": "0.2.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-spinner-style/-/nav-frontend-spinner-style-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-spinner-style/-/nav-frontend-spinner-style-0.2.5.tgz",
       "integrity": "sha512-PWSfscmNMbrnXRcXQUgBquU5479bNmO/sw3IwML6s6K/qyEYggRvJdGCbBEYyxXmoeDDjXGd2tkIVy5gja387A=="
     },
     "nav-frontend-stegindikator-style": {
       "version": "1.0.21",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-stegindikator-style/-/nav-frontend-stegindikator-style-1.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-stegindikator-style/-/nav-frontend-stegindikator-style-1.0.21.tgz",
       "integrity": "sha512-0NOmb2wJf7ZSVmwo0LIls+CkPGMbf/FeBNeXWK4Ft5jz/+uoIR9nx4VJcyHEwVe5GE7zr4+eYl1H258VoF9wMQ=="
     },
     "nav-frontend-typografi": {
       "version": "2.0.12",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-typografi/-/nav-frontend-typografi-2.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-typografi/-/nav-frontend-typografi-2.0.12.tgz",
       "integrity": "sha512-rj+K3JcDmIYb2uklMudwjXsMTPEX3xeFxWGy+itjbX9Ulr62S/V2q22afEfFZxD20IVAsSZToFG+SiufLYA1iA=="
     },
     "nav-frontend-typografi-style": {
       "version": "1.0.13",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-typografi-style/-/nav-frontend-typografi-style-1.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-typografi-style/-/nav-frontend-typografi-style-1.0.13.tgz",
       "integrity": "sha512-/jGp1jm0cjjjWYWf9m5JOkMBF/iHrSFbPjWj56jLxwinTJPFCTAj59i/yQP7VtBLVVpAlKfE8pMgYuhdYV2MEw==",
       "requires": {
         "nav-frontend-core": "^4.0.9"
@@ -8471,7 +8471,7 @@
     },
     "nearley": {
       "version": "2.16.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nearley/-/nearley-2.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
       "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
       "requires": {
         "commander": "^2.19.0",
@@ -8483,22 +8483,22 @@
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/negotiator/-/negotiator-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nice-try/-/nice-try-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
@@ -8506,17 +8506,17 @@
     },
     "node-forge": {
       "version": "0.7.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/node-forge/-/node-forge-0.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "requires": {
         "assert": "^1.1.1",
@@ -8546,19 +8546,19 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
     "node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
     "node-notifier": {
       "version": "5.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/node-notifier/-/node-notifier-5.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
       "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
       "requires": {
         "growly": "^1.3.0",
@@ -8570,7 +8570,7 @@
     },
     "node-releases": {
       "version": "1.1.24",
-      "resolved": "https://repo.adeo.no/repository/npm-public/node-releases/-/node-releases-1.1.24.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.24.tgz",
       "integrity": "sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==",
       "requires": {
         "semver": "^5.3.0"
@@ -8578,7 +8578,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -8589,7 +8589,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.11.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -8599,22 +8599,22 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
       "version": "3.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/normalize-url/-/normalize-url-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
@@ -8622,7 +8622,7 @@
     },
     "nth-check": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nth-check/-/nth-check-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
         "boolbase": "~1.0.0"
@@ -8630,32 +8630,32 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nwsapi/-/nwsapi-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
       "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw=="
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -8665,7 +8665,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -8673,7 +8673,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -8683,27 +8683,27 @@
     },
     "object-hash": {
       "version": "1.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-hash/-/object-hash-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
     "object-inspect": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-inspect/-/object-inspect-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
     },
     "object-is": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-is/-/object-is-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
       "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
@@ -8711,7 +8711,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object.assign/-/object.assign-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "^1.1.2",
@@ -8722,7 +8722,7 @@
     },
     "object.entries": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object.entries/-/object.entries-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
       "requires": {
         "define-properties": "^1.1.3",
@@ -8733,7 +8733,7 @@
     },
     "object.fromentries": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
       "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
       "requires": {
         "define-properties": "^1.1.2",
@@ -8744,7 +8744,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "requires": {
         "define-properties": "^1.1.2",
@@ -8753,7 +8753,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -8761,7 +8761,7 @@
     },
     "object.values": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/object.values/-/object.values-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "requires": {
         "define-properties": "^1.1.3",
@@ -8772,12 +8772,12 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -8785,12 +8785,12 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -8798,7 +8798,7 @@
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
@@ -8806,7 +8806,7 @@
     },
     "opn": {
       "version": "5.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/opn/-/opn-5.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
       "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
       "requires": {
         "is-wsl": "^1.1.0"
@@ -8814,7 +8814,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "~0.0.1",
@@ -8823,14 +8823,14 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
     "optimize-css-assets-webpack-plugin": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
       "integrity": "sha512-Rqm6sSjWtx9FchdP0uzTQDc7GXDKnwVEGoSxjezPkzMewx7gEWE9IMUYKmigTRC4U3RaNSwYVnUDLuIdtTpm0A==",
       "requires": {
         "cssnano": "^4.1.0",
@@ -8839,7 +8839,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
         "deep-is": "~0.1.3",
@@ -8852,7 +8852,7 @@
     },
     "original": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/original/-/original-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "requires": {
         "url-parse": "^1.4.3"
@@ -8860,12 +8860,12 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
     "os-locale": {
       "version": "3.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/os-locale/-/os-locale-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "requires": {
         "execa": "^1.0.0",
@@ -8875,17 +8875,17 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-each-series/-/p-each-series-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "requires": {
         "p-reduce": "^1.0.0"
@@ -8893,17 +8893,17 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-limit/-/p-limit-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "requires": {
         "p-try": "^2.0.0"
@@ -8911,7 +8911,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
         "p-limit": "^2.0.0"
@@ -8919,27 +8919,27 @@
     },
     "p-map": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-map/-/p-map-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
     },
     "p-reduce": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-reduce/-/p-reduce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "1.0.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pako/-/pako-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
       "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "parallel-transform": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "requires": {
         "cyclist": "~0.2.2",
@@ -8949,7 +8949,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
         "no-case": "^2.2.0"
@@ -8957,7 +8957,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "requires": {
         "callsites": "^3.0.0"
@@ -8965,14 +8965,14 @@
       "dependencies": {
         "callsites": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/callsites/-/callsites-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
           "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         }
       }
     },
     "parse-asn1": {
       "version": "5.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/parse-asn1/-/parse-asn1-5.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
       "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -8985,7 +8985,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
         "error-ex": "^1.3.1",
@@ -8994,7 +8994,7 @@
     },
     "parse5": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/parse5/-/parse5-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
         "@types/node": "*"
@@ -9002,59 +9002,59 @@
       "dependencies": {
         "@types/node": {
           "version": "12.0.10",
-          "resolved": "https://repo.adeo.no/repository/npm-public/@types/node/-/node-12.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
           "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
         }
       }
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-browserify/-/path-browserify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "1.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "requires": {
         "isarray": "0.0.1"
@@ -9062,14 +9062,14 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
         "pify": "^3.0.0"
@@ -9077,7 +9077,7 @@
     },
     "pbkdf2": {
       "version": "3.0.17",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "requires": {
         "create-hash": "^1.1.2",
@@ -9089,22 +9089,22 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
@@ -9112,7 +9112,7 @@
     },
     "pirates": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pirates/-/pirates-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "requires": {
         "node-modules-regexp": "^1.0.0"
@@ -9120,7 +9120,7 @@
     },
     "pkg-dir": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "requires": {
         "find-up": "^3.0.0"
@@ -9128,7 +9128,7 @@
     },
     "pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pkg-up/-/pkg-up-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
         "find-up": "^2.1.0"
@@ -9136,7 +9136,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
@@ -9144,7 +9144,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
@@ -9153,7 +9153,7 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-limit/-/p-limit-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
             "p-try": "^1.0.0"
@@ -9161,7 +9161,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
@@ -9169,19 +9169,19 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         }
       }
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pn/-/pn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "pnp-webpack-plugin": {
       "version": "1.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pnp-webpack-plugin/-/pnp-webpack-plugin-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.2.1.tgz",
       "integrity": "sha512-W6GctK7K2qQiVR+gYSv/Gyt6jwwIH4vwdviFqx+Y2jAtVf5eZyYIDf5Ac2NCDMBiX5yWscBLZElPTsyA1UtVVA==",
       "requires": {
         "ts-pnp": "^1.0.0"
@@ -9189,7 +9189,7 @@
     },
     "portfinder": {
       "version": "1.0.20",
-      "resolved": "https://repo.adeo.no/repository/npm-public/portfinder/-/portfinder-1.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
       "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
       "requires": {
         "async": "^1.5.2",
@@ -9199,12 +9199,12 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
       "version": "7.0.17",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss/-/postcss-7.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
       "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
       "requires": {
         "chalk": "^2.4.2",
@@ -9214,7 +9214,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -9224,7 +9224,7 @@
     },
     "postcss-attribute-case-insensitive": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
       "integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9233,12 +9233,12 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
@@ -9250,7 +9250,7 @@
     },
     "postcss-browser-comments": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-browser-comments/-/postcss-browser-comments-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-2.0.0.tgz",
       "integrity": "sha512-xGG0UvoxwBc4Yx4JX3gc0RuDl1kc4bVihCzzk6UC72YPfq5fu3c717Nu8Un3nvnq1BJ31gBnFXIG/OaUTnpHgA==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9258,7 +9258,7 @@
     },
     "postcss-calc": {
       "version": "7.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-calc/-/postcss-calc-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
       "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "requires": {
         "css-unit-converter": "^1.1.1",
@@ -9269,12 +9269,12 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
@@ -9286,7 +9286,7 @@
     },
     "postcss-color-functional-notation": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
       "integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9295,7 +9295,7 @@
     },
     "postcss-color-gray": {
       "version": "5.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
       "integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
       "requires": {
         "@csstools/convert-colors": "^1.4.0",
@@ -9305,7 +9305,7 @@
     },
     "postcss-color-hex-alpha": {
       "version": "5.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
       "integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
       "requires": {
         "postcss": "^7.0.14",
@@ -9314,7 +9314,7 @@
     },
     "postcss-color-mod-function": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
       "integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
       "requires": {
         "@csstools/convert-colors": "^1.4.0",
@@ -9324,7 +9324,7 @@
     },
     "postcss-color-rebeccapurple": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
       "integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9333,7 +9333,7 @@
     },
     "postcss-colormin": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
       "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "requires": {
         "browserslist": "^4.0.0",
@@ -9345,7 +9345,7 @@
     },
     "postcss-convert-values": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "requires": {
         "postcss": "^7.0.0",
@@ -9354,7 +9354,7 @@
     },
     "postcss-custom-media": {
       "version": "7.0.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
       "integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
       "requires": {
         "postcss": "^7.0.14"
@@ -9362,7 +9362,7 @@
     },
     "postcss-custom-properties": {
       "version": "8.0.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
       "integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
       "requires": {
         "postcss": "^7.0.17",
@@ -9371,7 +9371,7 @@
     },
     "postcss-custom-selectors": {
       "version": "5.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
       "integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9380,12 +9380,12 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
@@ -9397,7 +9397,7 @@
     },
     "postcss-dir-pseudo-class": {
       "version": "5.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
       "integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9406,12 +9406,12 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
@@ -9423,7 +9423,7 @@
     },
     "postcss-discard-comments": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
       "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9431,7 +9431,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9439,7 +9439,7 @@
     },
     "postcss-discard-empty": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9447,7 +9447,7 @@
     },
     "postcss-discard-overridden": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9455,7 +9455,7 @@
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
       "integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
       "requires": {
         "postcss": "^7.0.5",
@@ -9464,7 +9464,7 @@
     },
     "postcss-env-function": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
       "integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9473,7 +9473,7 @@
     },
     "postcss-flexbugs-fixes": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
       "integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9481,7 +9481,7 @@
     },
     "postcss-focus-visible": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
       "integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9489,7 +9489,7 @@
     },
     "postcss-focus-within": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
       "integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9497,7 +9497,7 @@
     },
     "postcss-font-variant": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
       "integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9505,7 +9505,7 @@
     },
     "postcss-gap-properties": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
       "integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9513,7 +9513,7 @@
     },
     "postcss-image-set-function": {
       "version": "3.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
       "integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9522,7 +9522,7 @@
     },
     "postcss-initial": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-initial/-/postcss-initial-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.0.tgz",
       "integrity": "sha512-WzrqZ5nG9R9fUtrA+we92R4jhVvEB32IIRTzfIG/PLL8UV4CvbF1ugTEHEFX6vWxl41Xt5RTCJPEZkuWzrOM+Q==",
       "requires": {
         "lodash.template": "^4.2.4",
@@ -9531,7 +9531,7 @@
     },
     "postcss-lab-function": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
       "integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
       "requires": {
         "@csstools/convert-colors": "^1.4.0",
@@ -9541,7 +9541,7 @@
     },
     "postcss-load-config": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
       "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
       "requires": {
         "cosmiconfig": "^5.0.0",
@@ -9550,7 +9550,7 @@
     },
     "postcss-loader": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-loader/-/postcss-loader-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "requires": {
         "loader-utils": "^1.1.0",
@@ -9561,7 +9561,7 @@
     },
     "postcss-logical": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-logical/-/postcss-logical-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
       "integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9569,7 +9569,7 @@
     },
     "postcss-media-minmax": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
       "integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9577,7 +9577,7 @@
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
       "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
       "requires": {
         "css-color-names": "0.0.4",
@@ -9588,7 +9588,7 @@
     },
     "postcss-merge-rules": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
       "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "requires": {
         "browserslist": "^4.0.0",
@@ -9601,7 +9601,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
             "dot-prop": "^4.1.1",
@@ -9613,7 +9613,7 @@
     },
     "postcss-minify-font-values": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "requires": {
         "postcss": "^7.0.0",
@@ -9622,7 +9622,7 @@
     },
     "postcss-minify-gradients": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
       "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
@@ -9633,7 +9633,7 @@
     },
     "postcss-minify-params": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
       "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
       "requires": {
         "alphanum-sort": "^1.0.0",
@@ -9646,7 +9646,7 @@
     },
     "postcss-minify-selectors": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
       "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
       "requires": {
         "alphanum-sort": "^1.0.0",
@@ -9657,7 +9657,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
             "dot-prop": "^4.1.1",
@@ -9669,7 +9669,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "requires": {
         "postcss": "^7.0.5"
@@ -9677,7 +9677,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "2.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
       "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
       "requires": {
         "postcss": "^7.0.6",
@@ -9687,7 +9687,7 @@
     },
     "postcss-modules-scope": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
       "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
       "requires": {
         "postcss": "^7.0.6",
@@ -9696,7 +9696,7 @@
     },
     "postcss-modules-values": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
       "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
       "requires": {
         "icss-replace-symbols": "^1.1.0",
@@ -9705,7 +9705,7 @@
     },
     "postcss-nesting": {
       "version": "7.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-nesting/-/postcss-nesting-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.0.tgz",
       "integrity": "sha512-WSsbVd5Ampi3Y0nk/SKr5+K34n52PqMqEfswu6RtU4r7wA8vSD+gM8/D9qq4aJkHImwn1+9iEFTbjoWsQeqtaQ==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9713,7 +9713,7 @@
     },
     "postcss-normalize": {
       "version": "7.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize/-/postcss-normalize-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize/-/postcss-normalize-7.0.1.tgz",
       "integrity": "sha512-NOp1fwrG+6kVXWo7P9SizCHX6QvioxFD/hZcI2MLxPmVnFJFC0j0DDpIuNw2tUDeCFMni59gCVgeJ1/hYhj2OQ==",
       "requires": {
         "@csstools/normalize.css": "^9.0.1",
@@ -9724,7 +9724,7 @@
     },
     "postcss-normalize-charset": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9732,7 +9732,7 @@
     },
     "postcss-normalize-display-values": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
       "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
@@ -9742,7 +9742,7 @@
     },
     "postcss-normalize-positions": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
       "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
@@ -9753,7 +9753,7 @@
     },
     "postcss-normalize-repeat-style": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
       "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
@@ -9764,7 +9764,7 @@
     },
     "postcss-normalize-string": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
       "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
       "requires": {
         "has": "^1.0.0",
@@ -9774,7 +9774,7 @@
     },
     "postcss-normalize-timing-functions": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
       "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
@@ -9784,7 +9784,7 @@
     },
     "postcss-normalize-unicode": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "requires": {
         "browserslist": "^4.0.0",
@@ -9794,7 +9794,7 @@
     },
     "postcss-normalize-url": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "requires": {
         "is-absolute-url": "^2.0.0",
@@ -9805,7 +9805,7 @@
     },
     "postcss-normalize-whitespace": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
       "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
       "requires": {
         "postcss": "^7.0.0",
@@ -9814,7 +9814,7 @@
     },
     "postcss-ordered-values": {
       "version": "4.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
       "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
       "requires": {
         "cssnano-util-get-arguments": "^4.0.0",
@@ -9824,7 +9824,7 @@
     },
     "postcss-overflow-shorthand": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
       "integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9832,7 +9832,7 @@
     },
     "postcss-page-break": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
       "integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9840,7 +9840,7 @@
     },
     "postcss-place": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-place/-/postcss-place-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
       "integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9849,7 +9849,7 @@
     },
     "postcss-preset-env": {
       "version": "6.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-preset-env/-/postcss-preset-env-6.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.6.0.tgz",
       "integrity": "sha512-I3zAiycfqXpPIFD6HXhLfWXIewAWO8emOKz+QSsxaUZb9Dp8HbF5kUf+4Wy/AxR33o+LRoO8blEWCHth0ZsCLA==",
       "requires": {
         "autoprefixer": "^9.4.9",
@@ -9893,7 +9893,7 @@
     },
     "postcss-pseudo-class-any-link": {
       "version": "6.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
       "integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
       "requires": {
         "postcss": "^7.0.2",
@@ -9902,12 +9902,12 @@
       "dependencies": {
         "cssesc": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/cssesc/-/cssesc-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss-selector-parser": {
           "version": "5.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "requires": {
             "cssesc": "^2.0.0",
@@ -9919,7 +9919,7 @@
     },
     "postcss-reduce-initial": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "requires": {
         "browserslist": "^4.0.0",
@@ -9930,7 +9930,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
       "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
       "requires": {
         "cssnano-util-get-match": "^4.0.0",
@@ -9941,7 +9941,7 @@
     },
     "postcss-replace-overflow-wrap": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
       "integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
       "requires": {
         "postcss": "^7.0.2"
@@ -9949,7 +9949,7 @@
     },
     "postcss-safe-parser": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
       "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
       "requires": {
         "postcss": "^7.0.0"
@@ -9957,7 +9957,7 @@
     },
     "postcss-selector-matches": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
       "integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -9966,7 +9966,7 @@
     },
     "postcss-selector-not": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
       "integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -9975,7 +9975,7 @@
     },
     "postcss-selector-parser": {
       "version": "6.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
       "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
       "requires": {
         "cssesc": "^3.0.0",
@@ -9985,7 +9985,7 @@
     },
     "postcss-svgo": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
       "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
       "requires": {
         "is-svg": "^3.0.0",
@@ -9996,7 +9996,7 @@
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "requires": {
         "alphanum-sort": "^1.0.0",
@@ -10006,12 +10006,12 @@
     },
     "postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "postcss-values-parser": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
       "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
       "requires": {
         "flatten": "^1.0.2",
@@ -10021,17 +10021,17 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "pretty-bytes": {
       "version": "5.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
       "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
     },
     "pretty-error": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pretty-error/-/pretty-error-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
         "renderkid": "^2.0.1",
@@ -10040,7 +10040,7 @@
     },
     "pretty-format": {
       "version": "24.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pretty-format/-/pretty-format-24.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
       "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
       "requires": {
         "@jest/types": "^24.8.0",
@@ -10051,34 +10051,34 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         }
       }
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/private/-/private-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise": {
       "version": "7.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/promise/-/promise-7.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "optional": true,
       "requires": {
@@ -10087,12 +10087,12 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "prompts": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prompts/-/prompts-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
       "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
       "requires": {
         "kleur": "^3.0.2",
@@ -10101,7 +10101,7 @@
     },
     "prop-types": {
       "version": "15.7.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prop-types/-/prop-types-15.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
         "loose-envify": "^1.4.0",
@@ -10111,7 +10111,7 @@
     },
     "prop-types-exact": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
       "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
       "requires": {
         "has": "^1.0.3",
@@ -10121,7 +10121,7 @@
     },
     "property-information": {
       "version": "5.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/property-information/-/property-information-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
       "integrity": "sha512-tODH6R3+SwTkAQckSp2S9xyYX8dEKYkeXw+4TmJzTxnNzd6mQPu1OD4f9zPrvw/Rm4wpPgI+Zp63mNSGNzUgHg==",
       "requires": {
         "xtend": "^4.0.1"
@@ -10129,7 +10129,7 @@
     },
     "proxy-addr": {
       "version": "2.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
@@ -10138,17 +10138,17 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
       "version": "1.1.33",
-      "resolved": "https://repo.adeo.no/repository/npm-public/psl/-/psl-1.1.33.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
       "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -10161,7 +10161,7 @@
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -10170,7 +10170,7 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/pumpify/-/pumpify-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
         "duplexify": "^3.6.0",
@@ -10180,7 +10180,7 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/pump/-/pump-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -10191,37 +10191,37 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/querystringify/-/querystringify-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "raf": {
       "version": "3.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/raf/-/raf-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
         "performance-now": "^2.1.0"
@@ -10229,12 +10229,12 @@
     },
     "railroad-diagrams": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
     },
     "randexp": {
       "version": "0.4.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/randexp/-/randexp-0.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -10243,7 +10243,7 @@
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/randombytes/-/randombytes-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -10251,7 +10251,7 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/randomfill/-/randomfill-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "^2.0.5",
@@ -10260,12 +10260,12 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/raw-body/-/raw-body-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
         "bytes": "3.1.0",
@@ -10276,14 +10276,14 @@
       "dependencies": {
         "bytes": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/bytes/-/bytes-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         }
       }
     },
     "react": {
       "version": "16.8.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react/-/react-16.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
       "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "requires": {
         "loose-envify": "^1.1.0",
@@ -10294,7 +10294,7 @@
     },
     "react-app-polyfill": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-app-polyfill/-/react-app-polyfill-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.1.tgz",
       "integrity": "sha512-LbVpT1NdzTdDDs7xEZdebjDrqsvKi5UyVKUQqtTYYNyC1JJYVAwNQWe4ybWvoT2V2WW9PGVO2u5Y6aVj4ER/Ow==",
       "requires": {
         "core-js": "3.0.1",
@@ -10307,12 +10307,12 @@
       "dependencies": {
         "core-js": {
           "version": "3.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/core-js/-/core-js-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
           "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
         },
         "promise": {
           "version": "8.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/promise/-/promise-8.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
           "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
           "requires": {
             "asap": "~2.0.6"
@@ -10320,14 +10320,14 @@
         },
         "regenerator-runtime": {
           "version": "0.13.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
           "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
     "react-autocomplete": {
       "version": "1.8.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-autocomplete/-/react-autocomplete-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-autocomplete/-/react-autocomplete-1.8.1.tgz",
       "integrity": "sha1-67vEAABqqRrVOLLRRye55+XQYxA=",
       "requires": {
         "dom-scroll-into-view": "1.0.1",
@@ -10336,7 +10336,7 @@
     },
     "react-collapse": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-collapse/-/react-collapse-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-4.0.3.tgz",
       "integrity": "sha512-OO4NhtEqFtz+1ma31J1B7+ezdRnzHCZiTGSSd/Pxoks9hxrZYhzFEddeYt05A/1477xTtdrwo7xEa2FLJyWGCQ==",
       "requires": {
         "prop-types": "^15.5.8"
@@ -10344,7 +10344,7 @@
     },
     "react-dev-utils": {
       "version": "9.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-dev-utils/-/react-dev-utils-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.1.tgz",
       "integrity": "sha512-pnaeMo/Pxel8aZpxk1WwxT3uXxM3tEwYvsjCYn5R7gNxjhN1auowdcLDzFB8kr7rafAj2rxmvfic/fbac5CzwQ==",
       "requires": {
         "@babel/code-frame": "7.0.0",
@@ -10376,12 +10376,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "browserslist": {
           "version": "4.5.4",
-          "resolved": "https://repo.adeo.no/repository/npm-public/browserslist/-/browserslist-4.5.4.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
           "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
           "requires": {
             "caniuse-lite": "^1.0.30000955",
@@ -10391,7 +10391,7 @@
         },
         "inquirer": {
           "version": "6.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/inquirer/-/inquirer-6.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
           "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
           "requires": {
             "ansi-escapes": "^3.2.0",
@@ -10411,7 +10411,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -10421,7 +10421,7 @@
     },
     "react-document-title": {
       "version": "2.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-document-title/-/react-document-title-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-document-title/-/react-document-title-2.0.3.tgz",
       "integrity": "sha1-u/kioNcUEvyUgkXkKDskEt9w8rk=",
       "requires": {
         "prop-types": "^15.5.6",
@@ -10430,7 +10430,7 @@
     },
     "react-dom": {
       "version": "16.8.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-dom/-/react-dom-16.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
       "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "requires": {
         "loose-envify": "^1.1.0",
@@ -10441,12 +10441,12 @@
     },
     "react-error-overlay": {
       "version": "5.1.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
       "integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q=="
     },
     "react-inlinesvg": {
       "version": "0.8.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-inlinesvg/-/react-inlinesvg-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-0.8.4.tgz",
       "integrity": "sha512-pMkYa09gsP+5mA5uYDon5TxJbu76rJqdPSQ9nTRZbVacH58Eo3tFxD0Z382cioxNrpeqWHI/hquzt00GaahnkA==",
       "requires": {
         "httpplease": "^0.16.4",
@@ -10455,7 +10455,7 @@
     },
     "react-intl": {
       "version": "2.9.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-intl/-/react-intl-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
       "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
       "requires": {
         "hoist-non-react-statics": "^3.3.0",
@@ -10467,28 +10467,28 @@
     },
     "react-is": {
       "version": "16.8.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-is/-/react-is-16.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
-      "version": "3.8.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-modal/-/react-modal-3.8.1.tgz",
-      "integrity": "sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.8.2.tgz",
+      "integrity": "sha512-wxNk94wy/DMh2LyJa8K+LyOQDhQfhKuBrZ4SxS091p75cpW+STfY+9GpAuvl6P6Yt2r/+wxYH8Z3G5Ww/L8Tiw==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.5.10",
         "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
+        "warning": "^4.0.3"
       }
     },
     "react-motion": {
       "version": "0.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-motion/-/react-motion-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
       "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
       "requires": {
         "performance-now": "^0.2.0",
@@ -10498,14 +10498,14 @@
       "dependencies": {
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/performance-now/-/performance-now-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
           "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
         }
       }
     },
     "react-redux": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-redux/-/react-redux-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.0.tgz",
       "integrity": "sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==",
       "requires": {
         "@babel/runtime": "^7.4.5",
@@ -10518,7 +10518,7 @@
     },
     "react-router": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-router/-/react-router-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
       "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
       "requires": {
         "@babel/runtime": "^7.1.2",
@@ -10535,7 +10535,7 @@
     },
     "react-router-dom": {
       "version": "5.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-router-dom/-/react-router-dom-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
       "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
@@ -10549,7 +10549,7 @@
     },
     "react-scripts": {
       "version": "3.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-scripts/-/react-scripts-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.0.1.tgz",
       "integrity": "sha512-LKEjBhVpEB+c312NeJhzF+NATxF7JkHNr5GhtwMeRS1cMeLElMeIu8Ye7WGHtDP7iz7ra4ryy48Zpo6G/cwWUw==",
       "requires": {
         "@babel/core": "7.4.3",
@@ -10609,13 +10609,13 @@
       "dependencies": {
         "fsevents": {
           "version": "2.0.6",
-          "resolved": "https://repo.adeo.no/repository/npm-public/fsevents/-/fsevents-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.6.tgz",
           "integrity": "sha512-vfmKZp3XPM36DNF0qhW+Cdxk7xm7gTEHY1clv1Xq1arwRQuKZgAhw+NZNWbJBtuaNxzNXwhfdPYRrvIbjfS33A==",
           "optional": true
         },
         "resolve": {
           "version": "1.10.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
           "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "requires": {
             "path-parse": "^1.0.6"
@@ -10623,12 +10623,12 @@
         },
         "semver": {
           "version": "6.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/semver/-/semver-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
           "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
         },
         "terser": {
           "version": "3.17.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/terser/-/terser-3.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
           "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
           "requires": {
             "commander": "^2.19.0",
@@ -10638,7 +10638,7 @@
         },
         "terser-webpack-plugin": {
           "version": "1.2.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
           "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
           "requires": {
             "cacache": "^11.0.2",
@@ -10655,7 +10655,7 @@
     },
     "react-scroll": {
       "version": "1.7.12",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-scroll/-/react-scroll-1.7.12.tgz",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.12.tgz",
       "integrity": "sha512-hvi3MixtYQC1FADODqWx6MSYaShBbsq7ElQBny/pmzrGtF4ubGLuDOGpzP3mvJjWZ66Cepujt4PBjysYV3itwg==",
       "requires": {
         "lodash.throttle": "^4.1.1",
@@ -10664,7 +10664,7 @@
     },
     "react-side-effect": {
       "version": "1.1.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-side-effect/-/react-side-effect-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
       "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
       "requires": {
         "exenv": "^1.2.1",
@@ -10673,7 +10673,7 @@
     },
     "react-test-renderer": {
       "version": "16.8.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
       "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
       "requires": {
         "object-assign": "^4.1.1",
@@ -10684,7 +10684,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
         "load-json-file": "^4.0.0",
@@ -10694,7 +10694,7 @@
     },
     "read-pkg-up": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "requires": {
         "find-up": "^3.0.0",
@@ -10703,7 +10703,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -10717,7 +10717,7 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/readdirp/-/readdirp-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -10727,7 +10727,7 @@
     },
     "realpath-native": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/realpath-native/-/realpath-native-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "requires": {
         "util.promisify": "^1.0.0"
@@ -10735,7 +10735,7 @@
     },
     "recursive-readdir": {
       "version": "2.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
@@ -10743,7 +10743,7 @@
     },
     "redux": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/redux/-/redux-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
       "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
       "requires": {
         "loose-envify": "^1.4.0",
@@ -10752,12 +10752,12 @@
     },
     "redux-devtools-extension": {
       "version": "2.13.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
       "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
     },
     "redux-logger": {
       "version": "3.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/redux-logger/-/redux-logger-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
       "requires": {
         "deep-diff": "^0.3.5"
@@ -10765,7 +10765,7 @@
     },
     "redux-saga": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/redux-saga/-/redux-saga-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.0.4.tgz",
       "integrity": "sha512-KrT7jg1TKf4raTwH2L4d6WMEqHTuScTHOkbLL25e9Az0DQC4Y5ciCOK8rh3NSRDiJ8DZUBwc784CXNRbGyU9qQ==",
       "requires": {
         "@redux-saga/core": "^1.0.3"
@@ -10773,22 +10773,22 @@
     },
     "redux-thunk": {
       "version": "2.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
       "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "regenerate": {
       "version": "1.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regenerate/-/regenerate-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "requires": {
         "regenerate": "^1.4.0"
@@ -10796,12 +10796,12 @@
     },
     "regenerator-runtime": {
       "version": "0.10.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.14.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
       "integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
       "requires": {
         "private": "^0.1.6"
@@ -10809,7 +10809,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -10818,17 +10818,17 @@
     },
     "regexp-tree": {
       "version": "0.1.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regexp-tree/-/regexp-tree-0.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
       "integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ=="
     },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regexpp/-/regexpp-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
     },
     "regexpu-core": {
       "version": "4.5.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regexpu-core/-/regexpu-core-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
       "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
       "requires": {
         "regenerate": "^1.4.0",
@@ -10841,12 +10841,12 @@
     },
     "regjsgen": {
       "version": "0.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regjsgen/-/regjsgen-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
       "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
     },
     "regjsparser": {
       "version": "0.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/regjsparser/-/regjsparser-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
       "requires": {
         "jsesc": "~0.5.0"
@@ -10854,14 +10854,14 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "rehype-parse": {
       "version": "6.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rehype-parse/-/rehype-parse-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.0.tgz",
       "integrity": "sha512-V2OjMD0xcSt39G4uRdMTqDXXm6HwkUbLMDayYKA/d037j8/OtVSQ+tqKwYWOuyBeoCs/3clXRe30VUjeMDTBSA==",
       "requires": {
         "hast-util-from-parse5": "^5.0.0",
@@ -10871,24 +10871,24 @@
       "dependencies": {
         "parse5": {
           "version": "5.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/parse5/-/parse5-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
           "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
         }
       }
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "renderkid": {
       "version": "2.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/renderkid/-/renderkid-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
       "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
       "requires": {
         "css-select": "^1.1.0",
@@ -10900,12 +10900,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -10915,17 +10915,17 @@
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "replace": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/replace/-/replace-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace/-/replace-1.1.0.tgz",
       "integrity": "sha512-0k9rtPG0MUDfJj77XtMCSJKOPdzSwVwM79ZQ6lZuFjqqXrQAMKIMp0g7/8GDAzeERxdktV/LzqbMtJ3yxB23lg==",
       "dev": true,
       "requires": {
@@ -10936,12 +10936,12 @@
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/request/-/request-2.88.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -10968,7 +10968,7 @@
     },
     "request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "requires": {
         "lodash": "^4.17.11"
@@ -10976,7 +10976,7 @@
     },
     "request-promise-native": {
       "version": "1.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
       "requires": {
         "request-promise-core": "1.1.2",
@@ -10986,32 +10986,32 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "requireindex": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/requireindex/-/requireindex-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
         "resolve-from": "^3.0.0"
@@ -11019,22 +11019,22 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-pathname": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
       "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
         "onetime": "^2.0.0",
@@ -11043,22 +11043,22 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rgb-regex": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE="
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
         "glob": "^7.1.3"
@@ -11066,7 +11066,7 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ripemd160/-/ripemd160-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
         "hash-base": "^3.0.0",
@@ -11075,7 +11075,7 @@
     },
     "rst-selector-parser": {
       "version": "2.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
       "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "requires": {
         "lodash.flattendeep": "^4.4.0",
@@ -11084,12 +11084,12 @@
     },
     "rsvp": {
       "version": "4.8.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rsvp/-/rsvp-4.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
         "is-promise": "^2.1.0"
@@ -11097,7 +11097,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
         "aproba": "^1.1.1"
@@ -11105,7 +11105,7 @@
     },
     "rxjs": {
       "version": "6.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/rxjs/-/rxjs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "requires": {
         "tslib": "^1.9.0"
@@ -11113,12 +11113,12 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -11126,12 +11126,12 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sane/-/sane-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
       "requires": {
         "@cnakazawa/watch": "^1.0.3",
@@ -11147,14 +11147,14 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "sass-loader": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sass-loader/-/sass-loader-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
       "integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
       "requires": {
         "clone-deep": "^2.0.1",
@@ -11167,7 +11167,7 @@
       "dependencies": {
         "clone-deep": {
           "version": "2.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/clone-deep/-/clone-deep-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
           "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
           "requires": {
             "for-own": "^1.0.0",
@@ -11178,7 +11178,7 @@
         },
         "for-own": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/for-own/-/for-own-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
             "for-in": "^1.0.1"
@@ -11186,7 +11186,7 @@
         },
         "shallow-clone": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/shallow-clone/-/shallow-clone-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
           "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
           "requires": {
             "is-extendable": "^0.1.1",
@@ -11196,7 +11196,7 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-5.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
@@ -11205,12 +11205,12 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "3.1.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/saxes/-/saxes-3.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
       "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
       "requires": {
         "xmlchars": "^2.1.1"
@@ -11218,7 +11218,7 @@
     },
     "scheduler": {
       "version": "0.13.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/scheduler/-/scheduler-0.13.6.tgz",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
       "requires": {
         "loose-envify": "^1.1.0",
@@ -11227,7 +11227,7 @@
     },
     "schema-utils": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/schema-utils/-/schema-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "requires": {
         "ajv": "^6.1.0",
@@ -11237,17 +11237,17 @@
     },
     "seamless-immutable": {
       "version": "7.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
       "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A=="
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
       "version": "1.10.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/selfsigned/-/selfsigned-1.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
       "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
       "requires": {
         "node-forge": "0.7.5"
@@ -11255,12 +11255,12 @@
     },
     "semver": {
       "version": "5.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/semver/-/semver-5.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "send": {
       "version": "0.17.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/send/-/send-0.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
@@ -11280,19 +11280,19 @@
       "dependencies": {
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
     "serialize-javascript": {
       "version": "1.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
       "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA=="
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/serve-index/-/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
         "accepts": "~1.3.4",
@@ -11306,7 +11306,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -11317,19 +11317,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
       }
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/serve-static/-/serve-static-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "~1.0.2",
@@ -11340,12 +11340,12 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -11356,7 +11356,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -11366,17 +11366,17 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -11385,7 +11385,7 @@
     },
     "shallow-clone": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "requires": {
         "is-extendable": "^0.1.1",
@@ -11396,7 +11396,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -11404,19 +11404,19 @@
         },
         "lazy-cache": {
           "version": "0.2.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
         }
       }
     },
     "shallowequal": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/shallowequal/-/shallowequal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
         "shebang-regex": "^1.0.0"
@@ -11424,12 +11424,12 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shell-quote": {
       "version": "1.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/shell-quote/-/shell-quote-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
         "array-filter": "~0.0.0",
@@ -11440,24 +11440,24 @@
       "dependencies": {
         "array-filter": {
           "version": "0.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/array-filter/-/array-filter-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
           "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
         }
       }
     },
     "shellwords": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/shellwords/-/shellwords-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
@@ -11465,24 +11465,24 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
     "sisteransi": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sisteransi/-/sisteransi-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
       "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
     },
     "slash": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -11492,7 +11492,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "^0.11.1",
@@ -11507,7 +11507,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -11515,7 +11515,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -11523,14 +11523,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "^1.0.0",
@@ -11540,7 +11540,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -11548,7 +11548,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -11556,7 +11556,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -11564,7 +11564,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -11576,7 +11576,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
@@ -11584,7 +11584,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -11594,7 +11594,7 @@
     },
     "sockjs": {
       "version": "0.3.19",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sockjs/-/sockjs-0.3.19.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
         "faye-websocket": "^0.10.0",
@@ -11603,7 +11603,7 @@
       "dependencies": {
         "faye-websocket": {
           "version": "0.10.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
             "websocket-driver": ">=0.5.1"
@@ -11613,7 +11613,7 @@
     },
     "sockjs-client": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sockjs-client/-/sockjs-client-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
       "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
       "requires": {
         "debug": "^3.2.5",
@@ -11626,7 +11626,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
@@ -11634,29 +11634,29 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "soknadsosialhjelp-mocksystemdata": {
       "version": "1.0.13",
-      "resolved": "https://repo.adeo.no/repository/npm-public/soknadsosialhjelp-mocksystemdata/-/soknadsosialhjelp-mocksystemdata-1.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/soknadsosialhjelp-mocksystemdata/-/soknadsosialhjelp-mocksystemdata-1.0.13.tgz",
       "integrity": "sha512-/lPYzDE+HS+1HsG/O0XqUnlM1DLVh/0WTcqFJUXYU8LcGR7X7bsftpo/gFXfnQHnFzr6I2i8WhMGGcggyk6cWA=="
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/source-list-map/-/source-list-map-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
       "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
         "atob": "^2.1.1",
@@ -11668,7 +11668,7 @@
     },
     "source-map-support": {
       "version": "0.5.12",
-      "resolved": "https://repo.adeo.no/repository/npm-public/source-map-support/-/source-map-support-0.5.12.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -11677,17 +11677,17 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "space-separated-tokens": {
       "version": "1.1.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
       "integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -11696,12 +11696,12 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -11710,12 +11710,12 @@
     },
     "spdx-license-ids": {
       "version": "3.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
       "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
     },
     "spdy": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/spdy/-/spdy-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
       "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
       "requires": {
         "debug": "^4.1.0",
@@ -11727,7 +11727,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -11735,14 +11735,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "requires": {
         "debug": "^4.1.0",
@@ -11755,7 +11755,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -11763,12 +11763,12 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/readable-stream/-/readable-stream-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
@@ -11780,7 +11780,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -11788,12 +11788,12 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
@@ -11809,7 +11809,7 @@
     },
     "ssri": {
       "version": "6.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ssri/-/ssri-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -11817,17 +11817,17 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stable/-/stable-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "stack-utils": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stack-utils/-/stack-utils-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -11836,7 +11836,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.adeo.no/repository/npm-public/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -11846,17 +11846,17 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "requires": {
         "inherits": "~2.0.1",
@@ -11865,7 +11865,7 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stream-each/-/stream-each-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -11874,7 +11874,7 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stream-http/-/stream-http-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -11886,12 +11886,12 @@
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-length": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/string-length/-/string-length-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "requires": {
         "astral-regex": "^1.0.0",
@@ -11900,7 +11900,7 @@
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/string-width/-/string-width-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -11909,7 +11909,7 @@
     },
     "string.prototype.trim": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
         "define-properties": "^1.1.2",
@@ -11919,7 +11919,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -11927,7 +11927,7 @@
     },
     "stringify-object": {
       "version": "3.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stringify-object/-/stringify-object-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
       "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "requires": {
         "get-own-enumerable-property-symbols": "^3.0.0",
@@ -11937,7 +11937,7 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
         "ansi-regex": "^3.0.0"
@@ -11945,12 +11945,12 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-comments": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/strip-comments/-/strip-comments-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
       "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
       "requires": {
         "babel-extract-comments": "^1.0.0",
@@ -11959,17 +11959,17 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-loader": {
       "version": "0.23.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/style-loader/-/style-loader-0.23.1.tgz",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
       "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
       "requires": {
         "loader-utils": "^1.1.0",
@@ -11978,7 +11978,7 @@
     },
     "stylehacks": {
       "version": "4.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/stylehacks/-/stylehacks-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
       "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "requires": {
         "browserslist": "^4.0.0",
@@ -11988,7 +11988,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
             "dot-prop": "^4.1.1",
@@ -12000,7 +12000,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
@@ -12008,7 +12008,7 @@
     },
     "svgo": {
       "version": "1.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/svgo/-/svgo-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
       "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
       "requires": {
         "chalk": "^2.4.1",
@@ -12029,7 +12029,7 @@
       "dependencies": {
         "css-select": {
           "version": "2.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/css-select/-/css-select-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
           "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
           "requires": {
             "boolbase": "^1.0.0",
@@ -12040,7 +12040,7 @@
         },
         "domutils": {
           "version": "1.7.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/domutils/-/domutils-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
           "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
           "requires": {
             "dom-serializer": "0",
@@ -12051,17 +12051,17 @@
     },
     "symbol-observable": {
       "version": "1.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
       "version": "5.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/table/-/table-5.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
       "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
       "requires": {
         "ajv": "^6.9.1",
@@ -12072,12 +12072,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -12087,7 +12087,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -12097,13 +12097,13 @@
     },
     "tapable": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tapable/-/tapable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "terser": {
-      "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/terser/-/terser-4.0.0.tgz",
-      "integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.0.2.tgz",
+      "integrity": "sha512-IWLuJqTvx97KP3uTYkFVn93cXO+EtlzJu8TdJylq+H0VBDlPMIfQA9MBS5Vc5t3xTEUG1q0hIfHMpAP2R+gWTw==",
       "requires": {
         "commander": "^2.19.0",
         "source-map": "~0.6.1",
@@ -12112,7 +12112,7 @@
     },
     "terser-webpack-plugin": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
       "integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
       "requires": {
         "cacache": "^11.3.2",
@@ -12129,7 +12129,7 @@
     },
     "test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
       "requires": {
         "glob": "^7.1.3",
@@ -12140,22 +12140,22 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "throat": {
       "version": "4.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/throat/-/throat-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://repo.adeo.no/repository/npm-public/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/through2/-/through2-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
         "readable-stream": "~2.3.6",
@@ -12164,12 +12164,12 @@
     },
     "thunky": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/thunky/-/thunky-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
       "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow=="
     },
     "timers-browserify": {
       "version": "2.0.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/timers-browserify/-/timers-browserify-2.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
         "setimmediate": "^1.0.4"
@@ -12177,22 +12177,22 @@
     },
     "timsort": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/timsort/-/timsort-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tiny-invariant": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
       "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
     },
     "tiny-warning": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tiny-warning/-/tiny-warning-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
       "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -12200,22 +12200,22 @@
     },
     "tmpl": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tmpl/-/tmpl-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -12223,7 +12223,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -12233,7 +12233,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
         "define-property": "^2.0.2",
@@ -12244,7 +12244,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
@@ -12253,12 +12253,12 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/toidentifier/-/toidentifier-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
         "psl": "^1.1.24",
@@ -12267,14 +12267,14 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
@@ -12282,27 +12282,27 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trough": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/trough/-/trough-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
       "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
     },
     "ts-pnp": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ts-pnp/-/ts-pnp-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
       "integrity": "sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA=="
     },
     "tslib": {
       "version": "1.10.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tslib/-/tslib-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tsutils": {
       "version": "3.14.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tsutils/-/tsutils-3.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
       "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
       "requires": {
         "tslib": "^1.8.1"
@@ -12310,12 +12310,12 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -12323,12 +12323,12 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -12336,7 +12336,7 @@
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "https://repo.adeo.no/repository/npm-public/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
@@ -12345,17 +12345,17 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
       "version": "3.4.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/typescript/-/typescript-3.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
       "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
     },
     "typescript-compare": {
       "version": "0.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
       "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
       "requires": {
         "typescript-logic": "^0.0.0"
@@ -12363,12 +12363,12 @@
     },
     "typescript-logic": {
       "version": "0.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
       "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
     },
     "typescript-tuple": {
       "version": "2.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
       "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
       "requires": {
         "typescript-compare": "^0.0.2"
@@ -12376,7 +12376,7 @@
     },
     "uglify-js": {
       "version": "3.4.10",
-      "resolved": "https://repo.adeo.no/repository/npm-public/uglify-js/-/uglify-js-3.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
       "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
       "requires": {
         "commander": "~2.19.0",
@@ -12385,19 +12385,19 @@
       "dependencies": {
         "commander": {
           "version": "2.19.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/commander/-/commander-2.19.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         }
       }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
@@ -12406,17 +12406,17 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
       "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "unified": {
       "version": "7.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unified/-/unified-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
       "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
       "requires": {
         "@types/unist": "^2.0.0",
@@ -12431,12 +12431,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "2.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-buffer/-/is-buffer-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
           "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         },
         "vfile": {
           "version": "3.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/vfile/-/vfile-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
           "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
           "requires": {
             "is-buffer": "^2.0.0",
@@ -12449,7 +12449,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
@@ -12460,17 +12460,17 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/uniqs/-/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unique-filename/-/unique-filename-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "requires": {
         "unique-slug": "^2.0.0"
@@ -12478,7 +12478,7 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unique-slug/-/unique-slug-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -12486,27 +12486,27 @@
     },
     "unist-util-stringify-position": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
       "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unquote": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unquote/-/unquote-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -12515,7 +12515,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -12525,7 +12525,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://repo.adeo.no/repository/npm-public/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -12535,24 +12535,24 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://repo.adeo.no/repository/npm-public/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
     },
     "upath": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/upath/-/upath-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
@@ -12560,12 +12560,12 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",
@@ -12574,14 +12574,14 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
     "url-loader": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/url-loader/-/url-loader-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
       "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
       "requires": {
         "loader-utils": "^1.1.0",
@@ -12591,14 +12591,14 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "https://repo.adeo.no/repository/npm-public/mime/-/mime-2.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
           "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         }
       }
     },
     "url-parse": {
       "version": "1.4.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/url-parse/-/url-parse-1.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
         "querystringify": "^2.1.1",
@@ -12607,7 +12607,7 @@
     },
     "urllite": {
       "version": "0.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/urllite/-/urllite-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/urllite/-/urllite-0.5.0.tgz",
       "integrity": "sha1-G3u5yj+w25Ug3hE0ZrvPfMNBRRo=",
       "requires": {
         "xtend": "~4.0.0"
@@ -12615,12 +12615,12 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/use/-/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/util/-/util-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "requires": {
         "inherits": "2.0.3"
@@ -12628,19 +12628,19 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/util.promisify/-/util.promisify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "requires": {
         "define-properties": "^1.1.2",
@@ -12649,22 +12649,22 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/utila/-/utila-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -12673,22 +12673,22 @@
     },
     "value-equal": {
       "version": "0.4.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/value-equal/-/value-equal-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
       "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/vendors/-/vendors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
       "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -12698,7 +12698,7 @@
     },
     "vfile": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/vfile/-/vfile-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
       "integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
       "requires": {
         "@types/unist": "^2.0.0",
@@ -12710,12 +12710,12 @@
       "dependencies": {
         "is-buffer": {
           "version": "2.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-buffer/-/is-buffer-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
           "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         },
         "unist-util-stringify-position": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
           "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
           "requires": {
             "@types/unist": "^2.0.2"
@@ -12723,7 +12723,7 @@
         },
         "vfile-message": {
           "version": "2.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/vfile-message/-/vfile-message-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
           "integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
           "requires": {
             "@types/unist": "^2.0.2",
@@ -12734,7 +12734,7 @@
     },
     "vfile-message": {
       "version": "1.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/vfile-message/-/vfile-message-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
       "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
@@ -12742,12 +12742,12 @@
     },
     "vm-browserify": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/vm-browserify/-/vm-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "requires": {
         "browser-process-hrtime": "^0.1.2"
@@ -12755,7 +12755,7 @@
     },
     "w3c-xmlserializer": {
       "version": "1.1.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
       "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
       "requires": {
         "domexception": "^1.0.1",
@@ -12765,23 +12765,23 @@
     },
     "walker": {
       "version": "1.0.7",
-      "resolved": "https://repo.adeo.no/repository/npm-public/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
       }
     },
     "warning": {
-      "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/watchpack/-/watchpack-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
         "chokidar": "^2.0.2",
@@ -12791,7 +12791,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
         "minimalistic-assert": "^1.0.0"
@@ -12799,17 +12799,17 @@
     },
     "web-namespaces": {
       "version": "1.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/web-namespaces/-/web-namespaces-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
       "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack": {
       "version": "4.29.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack/-/webpack-4.29.6.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.6.tgz",
       "integrity": "sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -12840,7 +12840,7 @@
     },
     "webpack-dev-middleware": {
       "version": "3.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
       "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
       "requires": {
         "memory-fs": "^0.4.1",
@@ -12851,14 +12851,14 @@
       "dependencies": {
         "mime": {
           "version": "2.4.4",
-          "resolved": "https://repo.adeo.no/repository/npm-public/mime/-/mime-2.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
           "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         }
       }
     },
     "webpack-dev-server": {
       "version": "3.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
       "integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
       "requires": {
         "ansi-html": "0.0.7",
@@ -12895,17 +12895,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -12913,7 +12913,7 @@
         },
         "decamelize": {
           "version": "2.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/decamelize/-/decamelize-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
           "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
           "requires": {
             "xregexp": "4.0.0"
@@ -12921,17 +12921,17 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -12939,7 +12939,7 @@
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -12947,7 +12947,7 @@
         },
         "yargs": {
           "version": "12.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/yargs/-/yargs-12.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
           "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
           "requires": {
             "cliui": "^4.0.0",
@@ -12966,7 +12966,7 @@
         },
         "yargs-parser": {
           "version": "10.1.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "requires": {
             "camelcase": "^4.1.0"
@@ -12976,7 +12976,7 @@
     },
     "webpack-log": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-log/-/webpack-log-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "requires": {
         "ansi-colors": "^3.0.0",
@@ -12985,7 +12985,7 @@
     },
     "webpack-manifest-plugin": {
       "version": "2.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
       "integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
       "requires": {
         "fs-extra": "^7.0.0",
@@ -12995,7 +12995,7 @@
     },
     "webpack-merge": {
       "version": "4.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-merge/-/webpack-merge-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
       "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
       "dev": true,
       "requires": {
@@ -13004,7 +13004,7 @@
     },
     "webpack-sources": {
       "version": "1.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-sources/-/webpack-sources-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
       "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
       "requires": {
         "source-list-map": "^2.0.0",
@@ -13013,7 +13013,7 @@
     },
     "websocket-driver": {
       "version": "0.7.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
       "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "requires": {
         "http-parser-js": ">=0.4.0 <0.4.11",
@@ -13023,12 +13023,12 @@
     },
     "websocket-extensions": {
       "version": "0.1.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "requires": {
         "iconv-lite": "0.4.24"
@@ -13036,17 +13036,17 @@
     },
     "whatwg-fetch": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -13056,7 +13056,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/which/-/which-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
@@ -13064,17 +13064,17 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "workbox-background-sync": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
       "integrity": "sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13082,7 +13082,7 @@
     },
     "workbox-broadcast-update": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
       "integrity": "sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13090,7 +13090,7 @@
     },
     "workbox-build": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-build/-/workbox-build-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.3.1.tgz",
       "integrity": "sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==",
       "requires": {
         "@babel/runtime": "^7.3.4",
@@ -13120,7 +13120,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "4.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/fs-extra/-/fs-extra-4.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -13132,7 +13132,7 @@
     },
     "workbox-cacheable-response": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
       "integrity": "sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13140,12 +13140,12 @@
     },
     "workbox-core": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-core/-/workbox-core-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.3.1.tgz",
       "integrity": "sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg=="
     },
     "workbox-expiration": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
       "integrity": "sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13153,7 +13153,7 @@
     },
     "workbox-google-analytics": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
       "integrity": "sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==",
       "requires": {
         "workbox-background-sync": "^4.3.1",
@@ -13164,7 +13164,7 @@
     },
     "workbox-navigation-preload": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
       "integrity": "sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13172,7 +13172,7 @@
     },
     "workbox-precaching": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
       "integrity": "sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13180,7 +13180,7 @@
     },
     "workbox-range-requests": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
       "integrity": "sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13188,7 +13188,7 @@
     },
     "workbox-routing": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-routing/-/workbox-routing-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.3.1.tgz",
       "integrity": "sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13196,7 +13196,7 @@
     },
     "workbox-strategies": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
       "integrity": "sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13204,7 +13204,7 @@
     },
     "workbox-streams": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-streams/-/workbox-streams-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.3.1.tgz",
       "integrity": "sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13212,12 +13212,12 @@
     },
     "workbox-sw": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-sw/-/workbox-sw-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.3.1.tgz",
       "integrity": "sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w=="
     },
     "workbox-webpack-plugin": {
       "version": "4.2.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-webpack-plugin/-/workbox-webpack-plugin-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-4.2.0.tgz",
       "integrity": "sha512-YZsiA+y/ns/GdWRaBsfYv8dln1ebWtGnJcTOg1ppO0pO1tScAHX0yGtHIjndxz3L/UUhE8b0NQE9KeLNwJwA5A==",
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -13227,7 +13227,7 @@
     },
     "workbox-window": {
       "version": "4.3.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/workbox-window/-/workbox-window-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.3.1.tgz",
       "integrity": "sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==",
       "requires": {
         "workbox-core": "^4.3.1"
@@ -13235,7 +13235,7 @@
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/worker-farm/-/worker-farm-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "requires": {
         "errno": "~0.1.7"
@@ -13243,7 +13243,7 @@
     },
     "worker-rpc": {
       "version": "0.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/worker-rpc/-/worker-rpc-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
       "integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
       "requires": {
         "microevent.ts": "~0.1.1"
@@ -13251,7 +13251,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -13260,12 +13260,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -13273,7 +13273,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -13283,7 +13283,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -13293,12 +13293,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/write/-/write-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "requires": {
         "mkdirp": "^0.5.1"
@@ -13306,7 +13306,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -13316,7 +13316,7 @@
     },
     "ws": {
       "version": "5.2.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ws/-/ws-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "requires": {
         "async-limiter": "~1.0.0"
@@ -13324,47 +13324,47 @@
     },
     "x-is-string": {
       "version": "0.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/x-is-string/-/x-is-string-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
     "xmlchars": {
       "version": "2.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/xmlchars/-/xmlchars-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.1.1.tgz",
       "integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w=="
     },
     "xmlhttprequest": {
       "version": "1.8.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xregexp": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/xregexp/-/xregexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
       "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "3.0.3",
-      "resolved": "https://repo.adeo.no/repository/npm-public/yallist/-/yallist-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "12.0.5",
-      "resolved": "https://repo.adeo.no/repository/npm-public/yargs/-/yargs-12.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
       "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "requires": {
         "cliui": "^4.0.0",
@@ -13383,14 +13383,14 @@
       "dependencies": {
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://repo.adeo.no/repository/npm-public/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         }
       }
     },
     "yargs-parser": {
       "version": "11.1.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
       "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "requires": {
         "camelcase": "^5.0.0",


### PR DESCRIPTION
Grunnen til at repo.adeo.no feiler på utviklermaskin (uten VPN) er at pakkenedlasting trigger SSO-login mot MSN. Jeg har ikke klart å finne noen grei måte å komme rundt det, men npmjs funker både i utviklerimage og på Jenkins (https://ci.adeo.no/job/team_digisos/job/soknadsosialhjelp/job/feature-cra-npmrc/), så kanskje like greit å bruke det, med mindre vi kommer til å bruke noen avhengigheter som ikke vil være tilgjengelig på utsiden?

Det er ikke sikkert vi trenger å angi registry eksplisitt når vi bruker npmjs, men da overstyrer vi i det minste eventuell konfig som ligger i ~/.npmrc i utviklerimage og på Jenkins, så da har vi litt mer kontroll over bygg på dette repoet.